### PR TITLE
feat(shared): implement smooth image loading with BlurHash and metadata support

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -86,7 +86,7 @@
 
 - **Atomic Design:**
   - Adopted Atomic Design for UI components in `shared/components/`.
-  - **Atoms:** Low-level components like `AppButton`, `AppAvatar`, `AppSwitch`, `AppClickableAction`.
+  - **Atoms:** Low-level components like `AppButton`, `AppAvatar`, `AppSwitch`, `AppClickableAction`, `AppImagePlaceholder`.
   - **Molecules:** Groups of atoms like `UserProfileHeader`, `UserProfileIcon`, `LoginIcon`.
   - **Organisms:** Complex UI sections like `MeSettingsList`, `SignInForm`, `HomeAppBar`, `ReaderOverlayWrapper`.
   - **Templates:** Page layouts like `ProfileTemplate`, `AuthTemplate`, `HomeTemplate`.

--- a/dump.json
+++ b/dump.json
@@ -1,0 +1,1105 @@
+{
+	"data": [
+		{
+			"id": "9ba0588f-0a6f-4a1d-8cf7-af141f63493d",
+			"title": "Siscon Ani to Brocon Imouto ga Shoujiki ni Nattara",
+			"alternativeTitle": [
+				"When a Siscon Brother and Brocon Sister Become Honest",
+				"Когда брат-сисконщик и сестра-броконщица решили быть честными.",
+				"シスコン兄とブラコン妹が正直になったら",
+				"一旦妹控哥哥與兄控妹妹變得坦率",
+				"시스콘 오빠와 브라콘 여동생이 솔직해진다면",
+				"Quando Um Irmão Siscon e Uma Irmã Brocon se Tornam Honestos"
+			],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/0e0daf05-706d-412d-bc08-e4e4f9da8b35/siscon-ani-to-brocon-imouto-ga-shoujiki-ni-nattara"
+			],
+			"description": "Even in high school, Ritsu and Uta really get along, but suddenly, they have to pretend to be lovers…!?  \n  \nThe real brother-sister exciting love comedy starts!!\n\n**Links:**\n- [Audio Dramas (Eng)](https://mega.nz/#F!l1MQlQjb!fIkmPLNx2pY-ezK90qtf9g)",
+			"publication": 2018,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-04-28T08:47:08.515Z",
+			"updatedAt": "2026-04-28T08:47:08.515Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "5ea5d7f9-4fbc-4589-811e-340516459ed9",
+					"url": "books/31/31a5940f-ba4f-4b5a-812d-a42a87cf7c7e.webp",
+					"title": "Volume 1",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:d530e30fbc4a360f",
+						"width": 844,
+						"height": 1200,
+						"entropy": 7.989578121228126,
+						"blurHash": "LRKS^_-VnC}_I-WTx?ot%zo|tPxZ",
+						"mimeType": "image/webp",
+						"sizeBytes": 160710,
+						"formatOrigin": "jpeg",
+						"dominantColor": "#815E6C"
+					},
+					"imageHash": "4b8fb3792ceba34fdcae6fd48a3efd4c66f4e45d2fba775753a54617a6daa357",
+					"originalUrl": "https://uploads.mangadex.org/covers/0e0daf05-706d-412d-bc08-e4e4f9da8b35/7079c4e5-9309-4497-8df4-6e471851ffdb.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/31/31a5940f-ba4f-4b5a-812d-a42a87cf7c7e.webp",
+			"coverMetadata": {
+				"pHash": "p:d530e30fbc4a360f",
+				"width": 844,
+				"height": 1200,
+				"entropy": 7.989578121228126,
+				"blurHash": "LRKS^_-VnC}_I-WTx?ot%zo|tPxZ",
+				"mimeType": "image/webp",
+				"sizeBytes": 160710,
+				"formatOrigin": "jpeg",
+				"dominantColor": "#815E6C"
+			}
+		},
+		{
+			"id": "f42bb03c-e28b-4fdf-8aee-bea69edec211",
+			"title": "Shinobigoto",
+			"alternativeTitle": [
+				"しのびごと",
+				"Синоби под прикрытием",
+				"Shinobi Undercover"
+			],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/8a38bcc4-0a52-4a46-9d02-7fc802048b1d/shinobigoto"
+			],
+			"description": "Even in modern Japan, ninja still hide in the shadows. Young ninja Yodaka has received his mission--protect high school student Aoi at all cost. But can a ninja survive the wild world of high school while also fulfilling his mission?\n___\n**Additional Links:**\n- **Alt Official English:** [VIZ](https://www.viz.com/shonenjump/chapters/shinobi-undercover)\n- [Official X](https://x.com/shinobigoto_off)",
+			"publication": 2024,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-04-28T08:47:08.375Z",
+			"updatedAt": "2026-04-28T08:47:08.375Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "c3cb69c3-d6ef-4389-88c8-975a427b0be9",
+					"url": "books/4c/4c1d8955-57eb-4db2-97a0-bea34625b8a8.webp",
+					"title": "Volume 2",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:ee322b107641db1f",
+						"width": 1304,
+						"height": 2048,
+						"entropy": 7.819500157382793,
+						"blurHash": "LFOyY6^tG9;l{lI.T0TB4%0T$,WU",
+						"mimeType": "image/webp",
+						"sizeBytes": 375206,
+						"formatOrigin": "jpeg",
+						"dominantColor": "#A1BDBB"
+					},
+					"imageHash": "259df0c616dcf721f10c45e0abdc30ae5d4cb0eb736bd4ae3d579fafb01f994f",
+					"originalUrl": "https://uploads.mangadex.org/covers/8a38bcc4-0a52-4a46-9d02-7fc802048b1d/dd6fef7e-aa50-49e0-99f5-0800f37ef2ba.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/4c/4c1d8955-57eb-4db2-97a0-bea34625b8a8.webp",
+			"coverMetadata": {
+				"pHash": "p:ee322b107641db1f",
+				"width": 1304,
+				"height": 2048,
+				"entropy": 7.819500157382793,
+				"blurHash": "LFOyY6^tG9;l{lI.T0TB4%0T$,WU",
+				"mimeType": "image/webp",
+				"sizeBytes": 375206,
+				"formatOrigin": "jpeg",
+				"dominantColor": "#A1BDBB"
+			}
+		},
+		{
+			"id": "e34ce5a6-f9f3-4fae-a0f5-df82fe6f750b",
+			"title": "Kimi wa Shuumatsu",
+			"alternativeTitle": [
+				"きみは終末",
+				"My Beloved Apocalypse",
+				"Meu Amado Apocalipse",
+				"Em Chính Là Ngày Tận Thế"
+			],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/c595a11d-8610-48c8-bd72-1755a5b6372b/kimi-wa-shuumatsu"
+			],
+			"description": "An 'apocalyptic' boy-meets-girl rom-com about high school boy Yutaka Kuromori and the beautiful, popular girl adored by everyone, Aru Hoshina. Yutaka might shyly deny it, insisting \"we're not dating,\" but Aru is always clinging to him, and the two are seen as the talk-of-the-school couple.\n\nBut behind what looks like an ordinary boy–girl high school relationship lies a secret — one so ruinous and capricious that, if mishandled, it could bring about the end of the world.",
+			"publication": 2025,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-04-28T08:44:05.723Z",
+			"updatedAt": "2026-04-28T08:44:05.723Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "1c0693ea-9dea-4708-9f89-ee51f1dc95c2",
+					"url": "books/a2/a209363e-a49d-4824-be46-138b8c9b8ceb.webp",
+					"title": "Volume 1",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:ecceed204a85cab5",
+						"width": 1801,
+						"height": 2560,
+						"entropy": 7.98589708818375,
+						"blurHash": "LQF=K]-BRjNa~q?HE2NG%2o}s.WB",
+						"mimeType": "image/webp",
+						"sizeBytes": 210830,
+						"formatOrigin": "jpeg",
+						"dominantColor": "#2A2328"
+					},
+					"imageHash": "0c8edf97c42383f55381248aaf08a57e86bf3f1f202ac77d40bad588c4ab20d2",
+					"originalUrl": "https://uploads.mangadex.org/covers/c595a11d-8610-48c8-bd72-1755a5b6372b/09f6e3e1-3ad2-443e-b09a-e22b85f070e0.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/a2/a209363e-a49d-4824-be46-138b8c9b8ceb.webp",
+			"coverMetadata": {
+				"pHash": "p:ecceed204a85cab5",
+				"width": 1801,
+				"height": 2560,
+				"entropy": 7.98589708818375,
+				"blurHash": "LQF=K]-BRjNa~q?HE2NG%2o}s.WB",
+				"mimeType": "image/webp",
+				"sizeBytes": 210830,
+				"formatOrigin": "jpeg",
+				"dominantColor": "#2A2328"
+			}
+		},
+		{
+			"id": "494bc126-3126-4ccb-a6c5-cf185dabfbda",
+			"title": "Isekai Walking",
+			"alternativeTitle": [
+				"異世界ウォーキング",
+				"Let's Take a Walk in Another World",
+				"Walking in Another World",
+				"Caminhando em outro mundo",
+				"Isekai Walking"
+			],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/72331318-7f5e-44b3-8510-12133149fde3/isekai-walking"
+			],
+			"description": "Ordinary student Sora has been summoned to another world as one of seven \"chosen heroes\" meant to battle the Demon King. While the other six are blessed with grandiose titles and superlative stats, Sora is stuck with no title, no level, and a single, underwhelming skill: he never gets tired from walking. After being judged useless to the cause, Sora is thrown out into the streets and left to fend for himself. Nevertheless, he grows determined to turn his unjust treatment and seemingly \"useless\" skill into a positive by earning money, making friends, and seeing sights he's never seen before!\n___\n[Official English Light Novel](https://j-novel.club/series/isekai-walking)",
+			"publication": 2025,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-04-28T08:44:05.474Z",
+			"updatedAt": "2026-04-28T08:44:05.474Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "fd2733fd-75ea-4a4f-bc56-e80fa98269ba",
+					"url": "books/1d/1db39901-fe69-4f07-a545-e7bbb7d6e0d6.webp",
+					"title": "Volume 1",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:851f7d4f29d01e52",
+						"width": 3024,
+						"height": 4299,
+						"entropy": 7.964189134461609,
+						"blurHash": "LHLD[Vm?4:W,MgI9NFx]02n$xtoz",
+						"mimeType": "image/webp",
+						"sizeBytes": 870680,
+						"formatOrigin": "jpeg",
+						"dominantColor": "#865864"
+					},
+					"imageHash": "6af08acfab8ee79232273970f76ebd72c09504a0e81fa452857122bf36166beb",
+					"originalUrl": "https://uploads.mangadex.org/covers/72331318-7f5e-44b3-8510-12133149fde3/f7f6b1b6-fa53-4710-8366-01cbc667958d.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/1d/1db39901-fe69-4f07-a545-e7bbb7d6e0d6.webp",
+			"coverMetadata": {
+				"pHash": "p:851f7d4f29d01e52",
+				"width": 3024,
+				"height": 4299,
+				"entropy": 7.964189134461609,
+				"blurHash": "LHLD[Vm?4:W,MgI9NFx]02n$xtoz",
+				"mimeType": "image/webp",
+				"sizeBytes": 870680,
+				"formatOrigin": "jpeg",
+				"dominantColor": "#865864"
+			}
+		},
+		{
+			"id": "a8f5267f-59d5-413a-a5a2-f1dfddbfc811",
+			"title": "Henkyou ni Tsuihousareta Dai 5 Ouji wa \"Kouun\" Skill de Sakusaku Ikinobimasu",
+			"alternativeTitle": [
+				"辺境に追放された第5王子は【幸運】スキルでさくさく生き延びます",
+				"The Fifth Prince Exiled to the Frontier Survives with His [Luck] Skill"
+			],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/fcd1696b-b8dc-4900-b6a2-58f6c6472de6/henkyou-ni-tsuihousareta-dai-5-ouji-wa-kouun-skill-de-sakusaku-ikinobimasu"
+			],
+			"description": "\"Don't underestimate my reincarnation cheat!\"\n\nElroy, the fifth prince of the Norgard royal family. He possesses the memories of his previous life and a cheat skill bestowed upon him during his reincarnation, which grants him luck that can turn the tide in dire situations [Luck - All or Nothing]. Although Elroy was recognized as a prodigy from a young age, his brilliance made him a target of disdain from his brothers, leading to his forced exile to the desolate and remote region of Ouroboroslant, where he was destined to die a miserable death. However, liberated from the palace's constraints, Elroy, alongside the strongest maid, utilizes his reincarnation cheat to transform the barren wasteland into a magnificent territory!",
+			"publication": 2024,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-04-28T08:44:05.072Z",
+			"updatedAt": "2026-04-28T08:44:05.072Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "f9ac274c-53e0-4f5e-8689-f2eb486df0f7",
+					"url": "books/ee/ee7b4b0d-78cc-445d-acca-3d8f33d7df12.webp",
+					"title": "Volume 1",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:ea95eb5c84603b9a",
+						"width": 1500,
+						"height": 2134,
+						"entropy": 7.982806972851475,
+						"blurHash": "LTKB5q}?%LxG^QU^9]WX.8xE.8ay",
+						"mimeType": "image/webp",
+						"sizeBytes": 278342,
+						"formatOrigin": "jpeg",
+						"dominantColor": "#5B2344"
+					},
+					"imageHash": "b75fc3dfd7b539dc12a37947edaf45cc1f467b49fe4f7bf94e3cc28dcec20fd1",
+					"originalUrl": "https://uploads.mangadex.org/covers/fcd1696b-b8dc-4900-b6a2-58f6c6472de6/db405ddc-32a1-4a4e-88bb-92e1abad369e.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/ee/ee7b4b0d-78cc-445d-acca-3d8f33d7df12.webp",
+			"coverMetadata": {
+				"pHash": "p:ea95eb5c84603b9a",
+				"width": 1500,
+				"height": 2134,
+				"entropy": 7.982806972851475,
+				"blurHash": "LTKB5q}?%LxG^QU^9]WX.8xE.8ay",
+				"mimeType": "image/webp",
+				"sizeBytes": 278342,
+				"formatOrigin": "jpeg",
+				"dominantColor": "#5B2344"
+			}
+		},
+		{
+			"id": "9b92c372-0cfa-4779-a938-39cf0362f49c",
+			"title": "Happy Ending Pancakes",
+			"alternativeTitle": ["ハッピーエンドパンケーキ"],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/8bd5bc25-4305-4955-be8e-63858b87e548/happy-ending-pancakes"
+			],
+			"description": "",
+			"publication": 2026,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-04-28T08:42:34.954Z",
+			"updatedAt": "2026-04-28T08:42:34.954Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "402e72cd-1b8b-4dd2-96a6-25dda17074bd",
+					"url": "https://uploads.mangadex.org/covers/8bd5bc25-4305-4955-be8e-63858b87e548/824d547f-b66b-4ed1-a975-529758756615.jpg",
+					"title": "Volume 1",
+					"index": 0,
+					"metadata": null,
+					"imageHash": "60a3f640f3bf7f9f44fe9890edb2c796442fc84da21c48b0015d617dd56d40d1",
+					"originalUrl": "https://uploads.mangadex.org/covers/8bd5bc25-4305-4955-be8e-63858b87e548/824d547f-b66b-4ed1-a975-529758756615.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://uploads.mangadex.org/covers/8bd5bc25-4305-4955-be8e-63858b87e548/824d547f-b66b-4ed1-a975-529758756615.jpg",
+			"coverMetadata": null
+		},
+		{
+			"id": "225e1952-492d-4597-98ca-26a7272fa795",
+			"title": "Aishiteru Game o Owarasetai",
+			"alternativeTitle": [
+				"愛してるゲームを終わらせたい",
+				"Aishiteru Game wo Owarasetai",
+				"I Want to End This Love Game",
+				"I Want To End This “I Love You” Game",
+				"I Want to End the Game That I Love",
+				"Ik wil een einde aan het liefdesspel",
+				"Je veux finir le jeu du \"je t'aime\"",
+				"Je veux en finir avec le jeu de l'amour",
+				"Eu quero acabar com o jogo do \"eu te amo\"",
+				"เกมสารภาพรักนี้น่ะเรามาจบกันเถอะ",
+				"想让“我爱你”游戏快点结束"
+			],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/acdbf57f-bf54-41b4-8d92-b3f3d14c852e/aishiteru-game-o-owarasetai"
+			],
+			"description": "Childhood friends who've been together since they were little. They both realize their feelings for each other, but they're too close to be honest. What connects them is the I Love You Game that they've been playing since they were little. The conclusion of their love is entrusted to this silly game, where you win if you make the other person embarrassed!",
+			"publication": 2025,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-04-28T08:41:02.461Z",
+			"updatedAt": "2026-04-28T08:41:02.461Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "3a248a0d-bf39-45f4-896a-09f921d27658",
+					"url": "books/15/15db75f9-1883-4cfa-844c-d1f2f028cf30.webp",
+					"title": "Volume 5",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:ee3f259b129243c9",
+						"width": 1445,
+						"height": 2048,
+						"entropy": 7.984457494042266,
+						"blurHash": "LUN^3w-ot,S600MxoKbZELD%oJS4",
+						"mimeType": "image/webp",
+						"sizeBytes": 274460,
+						"formatOrigin": "jpeg",
+						"dominantColor": "#E4C7CD"
+					},
+					"imageHash": "7ec8137ec2d6b3dfa574355ae6ec9a0f07b8f35a9c7f9dba4bfd3fd1ea6a0c3b",
+					"originalUrl": "https://uploads.mangadex.org/covers/acdbf57f-bf54-41b4-8d92-b3f3d14c852e/fa2ab156-6f44-4218-abe3-fa5d18d8a573.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/15/15db75f9-1883-4cfa-844c-d1f2f028cf30.webp",
+			"coverMetadata": {
+				"pHash": "p:ee3f259b129243c9",
+				"width": 1445,
+				"height": 2048,
+				"entropy": 7.984457494042266,
+				"blurHash": "LUN^3w-ot,S600MxoKbZELD%oJS4",
+				"mimeType": "image/webp",
+				"sizeBytes": 274460,
+				"formatOrigin": "jpeg",
+				"dominantColor": "#E4C7CD"
+			}
+		},
+		{
+			"id": "84b872d8-5d14-438b-81f6-afbfea734e77",
+			"title": "Absolute Ben 10",
+			"alternativeTitle": [],
+			"type": "manhua",
+			"originalUrl": [
+				"https://mangadex.org/title/2e0ef1ea-527e-438a-be1f-c6078db62fad/absolute-ben-10"
+			],
+			"description": "",
+			"publication": 2025,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-04-28T08:41:02.195Z",
+			"updatedAt": "2026-04-28T08:41:02.195Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "f07ecdac-6d9a-414a-9304-e1190ac2afa5",
+					"url": "books/29/29c9a7a8-a178-4048-8111-ea3a36a8bc36.webp",
+					"title": "Volume 1",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:acccb6e897859a89",
+						"width": 1080,
+						"height": 1080,
+						"entropy": 7.984098049615281,
+						"blurHash": "LPB=H^QI.gMP_1Omw6Rl.NRjxbW:",
+						"mimeType": "image/webp",
+						"sizeBytes": 94078,
+						"formatOrigin": "jpeg",
+						"dominantColor": "#575E5C"
+					},
+					"imageHash": "287ed9f80b4b9e4ee29f2062fe256e1ac7dd39be670b061722eecd1e606f9d6f",
+					"originalUrl": "https://uploads.mangadex.org/covers/2e0ef1ea-527e-438a-be1f-c6078db62fad/39777271-bc18-4e68-a476-928a7cdaa2e4.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/29/29c9a7a8-a178-4048-8111-ea3a36a8bc36.webp",
+			"coverMetadata": {
+				"pHash": "p:acccb6e897859a89",
+				"width": 1080,
+				"height": 1080,
+				"entropy": 7.984098049615281,
+				"blurHash": "LPB=H^QI.gMP_1Omw6Rl.NRjxbW:",
+				"mimeType": "image/webp",
+				"sizeBytes": 94078,
+				"formatOrigin": "jpeg",
+				"dominantColor": "#575E5C"
+			}
+		},
+		{
+			"id": "05b15a20-9890-4117-a681-e04648e42ca2",
+			"title": "Tonari no Kuderella wo Amayakashitara, Uchi no Aikagi wo Watasu Koto ni Natta",
+			"alternativeTitle": [
+				"隣のクーデレラを甘やかしたら、ウチの合鍵を渡すことになった",
+				"Tonari no Kuderella o Amayakashitara, Uchi no Aikagi o Watasu Koto ni Natta",
+				"I Spoiled \"Kuderella\" Next Door and I'm Going to Give Her a Key to My House",
+				"Khi Tôi Nuông Chiều Cô Nàng Kuuderella Nhà Bên, Cuối Cùng Thì Tôi Đã Đưa Chìa Khóa Nhà Cho Cô Ấy."
+			],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/7e5916f3-e271-4041-805a-23b932bb5b91/tonari-no-kuderella-wo-amayakashitara-uchi-no-aikagi-wo-watasu-koto-ni-natta"
+			],
+			"description": "Katagiri Naomi, a high school student who lived alone for two years, meets a beautiful girl with black hair and blue eyes, who moves into the apartment next door. The girl's name is Yui. It seemed that she really was a noblewoman, and her nickname was \"Quderella\" because of her nonchalant attitude at school. Naomi knows that Yui doesn't want to depend on others, but she's actually quite naive, so Naomi decides to help her.\n\n\"Today what are we having at night... Karaage chicken, huh?\"\n\"That's right because the price of chicken is discounted today\"\n\"I love your fried chicken so I'm really looking forward to it\"",
+			"publication": 2025,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-03-27T18:11:47.954Z",
+			"updatedAt": "2026-03-27T18:11:47.954Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "39124a62-faae-4568-824a-ec3e16fdbbae",
+					"url": "books/fd/fd856a72-2bd2-4c4b-a46d-d2af3a4e7a3a.webp",
+					"title": "Volume 1",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:bb9df284f029916c",
+						"width": 1801,
+						"height": 2560,
+						"entropy": 7.999023912270225,
+						"blurHash": "LLKUNF4Tx^%g_3MxoexvyF?a-p%M",
+						"mimeType": "image/webp",
+						"sizeBytes": 285244,
+						"formatOrigin": "webp",
+						"dominantColor": "#40394A"
+					},
+					"imageHash": "43af20b3f3a46acbe632bbfc5f11d5935620dbb763f9ff77149a5c2ab3e845bb",
+					"originalUrl": "https://uploads.mangadex.org/covers/7e5916f3-e271-4041-805a-23b932bb5b91/6fcc6fa1-f088-4836-9d81-370533ffcb44.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/fd/fd856a72-2bd2-4c4b-a46d-d2af3a4e7a3a.webp",
+			"coverMetadata": {
+				"pHash": "p:bb9df284f029916c",
+				"width": 1801,
+				"height": 2560,
+				"entropy": 7.999023912270225,
+				"blurHash": "LLKUNF4Tx^%g_3MxoexvyF?a-p%M",
+				"mimeType": "image/webp",
+				"sizeBytes": 285244,
+				"formatOrigin": "webp",
+				"dominantColor": "#40394A"
+			}
+		},
+		{
+			"id": "2607b0d6-c9c2-41a2-9403-f73c7513ed3d",
+			"title": "Majo Taisen - 32-nin no Isai no Majo wa Koroshiau",
+			"alternativeTitle": [
+				"魔女大戦　32人の異才の魔女は殺し合う",
+				"The War of Greedy Witches",
+				"Война Ведьм",
+				"Війна відьом",
+				"Ma nữ đại chiến"
+			],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/2b37189e-0bb2-4586-9757-b3fe6acd77b3/majo-taisen-32-nin-no-isai-no-majo-wa-koroshiau?tab=chapters"
+			],
+			"description": "Joan of Arc, the hero who saved France, was sentenced to be burned at the stake. But at the moment of her death, a demon sent her to another world. There, she found 32 women from across history, known as \"witches\".\n___\n**Alt Official Raw:** [MangaHot](https://mangahot.jp/site/works/z_R0171)",
+			"publication": 2020,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-03-27T18:09:46.957Z",
+			"updatedAt": "2026-03-27T18:09:46.957Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "d0c6b6aa-4135-4d44-9bfc-f04e306ae081",
+					"url": "books/7f/7f3110a1-b1d2-43f5-8999-28d681d0914e.webp",
+					"title": "Volume 5",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:97e3c89fe28a18ac",
+						"width": 1440,
+						"height": 2048,
+						"entropy": 7.999124398638567,
+						"blurHash": "LGJj[8IVMK?I{x?b-;Md^+-UOXVY",
+						"mimeType": "image/webp",
+						"sizeBytes": 332386,
+						"formatOrigin": "webp",
+						"dominantColor": "#9F8DA2"
+					},
+					"imageHash": "00794415a1a71343e3d346af0d4b06c6c2af59d3b8748a20a99ead1ce4bfe344",
+					"originalUrl": "https://uploads.mangadex.org/covers/2b37189e-0bb2-4586-9757-b3fe6acd77b3/18d6bdc8-b15f-41eb-85ed-06faf85e232e.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/7f/7f3110a1-b1d2-43f5-8999-28d681d0914e.webp",
+			"coverMetadata": {
+				"pHash": "p:97e3c89fe28a18ac",
+				"width": 1440,
+				"height": 2048,
+				"entropy": 7.999124398638567,
+				"blurHash": "LGJj[8IVMK?I{x?b-;Md^+-UOXVY",
+				"mimeType": "image/webp",
+				"sizeBytes": 332386,
+				"formatOrigin": "webp",
+				"dominantColor": "#9F8DA2"
+			}
+		},
+		{
+			"id": "869e77e3-5edf-4bc1-a795-b4530b4e4837",
+			"title": "Maigo ni Natteita Youjo o Tasuketara, Otonari ni Sumu Bishoujo Ryuugakusei ga Ie ni Asobi ni Kuru you ni natta Ken ni tsuite",
+			"alternativeTitle": [
+				"迷子になっていた幼女を助けたら、お隣に住む美少女留学生が家に遊びに来るようになった件について",
+				"The Story of How a Beautiful Foreign Student Who Lives Next Door Started to Visit My House After I Helped a Lost Little Girl",
+				"After Coincidentally Saving the New Transfer Student's Little Sister, We Gradually Grew Closer",
+				"আমার পাশের বাসার বিদেশিনী ও তার ছোট বোনের গল্প",
+				"Weil ich einem kleinen Mädchen geholfen habe, kommt jetzt die hübsche Austauschschülerin von nebenan zu mir nach Hause",
+				"Opowieść o Tym, Jak Piękna Uczennica Zza Granicy Mieszkająca Po Sąsiedzku Zaczęła Odwiedzać Mnie W Domu, Po Tym Jak Pomogłem Zagubionej Małej Dziewczynce",
+				"A História de como Uma Linda Estudante Estrangeira que Mora ao Lado Começou a Visitar Minha Casa Depois que Ajudei Uma Menininha Perdida",
+				"Sau Khi Tình Cờ Giúp Đỡ Một Bé Gái Lạc Đường, Nàng Mỹ Nữ Du Học Sinh Nhà Bên Thường Xuyên Lui Tới Căn Hộ Của Tôi",
+				"Красавицы-сестрёнки по соседству",
+				"Depuis que j'ai secouru une fillette égarée, la ravissante étudiante étrangère d'à côté vient souvent traîner à la maison."
+			],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/a287ef9c-3718-4c6f-80be-44e404b78641/maigo-ni-natteita-youjo-o-tasuketara-otonari-ni-sumu-bishoujo-ryuugakusei-ga-ie-ni-asobi-ni-kuru-you"
+			],
+			"description": "One day, Charlotte Bennett transferred to Aoyagi Akihito's class. Her proper and refined mannerisms and adorable appearance captured the hearts of his classmates, but Akihito calmly takes a step back, feeling that she \"lives in a different world.\" However, helping Charlotte's lost sister, Emma, throws his daily life into upheaval...?!",
+			"publication": 2024,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-03-27T18:09:16.846Z",
+			"updatedAt": "2026-03-27T18:09:16.846Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "2ceae8b3-0572-4377-8eb3-92bb1adca825",
+					"url": "books/32/32a38748-cf0e-47fc-85ce-9d4c44968a7d.webp",
+					"title": "Volume 1",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:bfd4e21cc032cd53",
+						"width": 1440,
+						"height": 2048,
+						"entropy": 7.999129298911912,
+						"blurHash": "LMJky99Z%Mo|_NWBaexu%#xZ%LoM",
+						"mimeType": "image/webp",
+						"sizeBytes": 260662,
+						"formatOrigin": "webp",
+						"dominantColor": "#7D8A8F"
+					},
+					"imageHash": "427032e28a67b20867d5799d728bb4b2e9203b7fde9c92abfd1fbd4f60c8e948",
+					"originalUrl": "https://uploads.mangadex.org/covers/a287ef9c-3718-4c6f-80be-44e404b78641/2ebdbab1-6686-49c0-a93e-0bbd72ac7b08.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/32/32a38748-cf0e-47fc-85ce-9d4c44968a7d.webp",
+			"coverMetadata": {
+				"pHash": "p:bfd4e21cc032cd53",
+				"width": 1440,
+				"height": 2048,
+				"entropy": 7.999129298911912,
+				"blurHash": "LMJky99Z%Mo|_NWBaexu%#xZ%LoM",
+				"mimeType": "image/webp",
+				"sizeBytes": 260662,
+				"formatOrigin": "webp",
+				"dominantColor": "#7D8A8F"
+			}
+		},
+		{
+			"id": "1796a50b-90b8-4c3b-bbd9-c8837c05d32a",
+			"title": "Kunon the Sorcerer Can See",
+			"alternativeTitle": [
+				"魔術師クノンは見えている",
+				"Majutsushi Kunon wa Miete Iru",
+				"Kunon the Sorcerer Can See Through",
+				"Kunon, o feiticeiro, pode ver"
+			],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/77c4966f-ead7-45bb-87e0-9ac618b11e8e/kunon-the-sorcerer-can-see"
+			],
+			"description": "Kunon Gurion, who was born blind, has one goal in life: finding a way to use his magic to see, something no one has ever done before. Luckily, Kunon’s talent for magic leads him to quickly surpass his teacher. Before long, his name reaches even the royal palace, earning him the rare opportunity to study under a powerful mentor.",
+			"publication": 2025,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-03-27T18:09:16.613Z",
+			"updatedAt": "2026-03-27T18:09:16.613Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "47c96279-ad82-4e9f-859a-5e0de5f64d35",
+					"url": "books/79/7913b5c1-de9e-434d-90d6-be8704c17a19.webp",
+					"title": "Volume 3",
+					"index": 2,
+					"metadata": {
+						"pHash": "p:eeb153d49146b853",
+						"width": 1798,
+						"height": 2560,
+						"entropy": 7.999029277911451,
+						"blurHash": "LRJ[I#xt?bWF~pRjx[t7s9ofWAxt",
+						"mimeType": "image/webp",
+						"sizeBytes": 303496,
+						"formatOrigin": "webp",
+						"dominantColor": "#363231"
+					},
+					"imageHash": "a5567126523acd16e0dc9b3aec97c8359f8fd46fdd9b5431aec5452e85568acc",
+					"originalUrl": "https://uploads.mangadex.org/covers/77c4966f-ead7-45bb-87e0-9ac618b11e8e/5e83f758-3dbf-4a52-9630-976589f1e1a6.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/79/7913b5c1-de9e-434d-90d6-be8704c17a19.webp",
+			"coverMetadata": {
+				"pHash": "p:eeb153d49146b853",
+				"width": 1798,
+				"height": 2560,
+				"entropy": 7.999029277911451,
+				"blurHash": "LRJ[I#xt?bWF~pRjx[t7s9ofWAxt",
+				"mimeType": "image/webp",
+				"sizeBytes": 303496,
+				"formatOrigin": "webp",
+				"dominantColor": "#363231"
+			}
+		},
+		{
+			"id": "5140f19f-0037-4de1-bbba-7511e5c1bc4d",
+			"title": "Guild no Uketsukejou Desu ga, Zangyou wa Iya Nanode Boss wo Solo Toubatsu Shiyou to Omoimasu",
+			"alternativeTitle": [
+				"ギルドの受付嬢ですが、残業は嫌なのでボスをソロ討伐しようと思います",
+				"Guild no Uketsukejou Desu ga, Zangyou wa Iya Nanode Boss o Solo Toubatsu Shiyou to Omoimasu",
+				"I May Be a Guild Receptionist, but I'll Solo Any Boss to Clock Out on Time",
+				"虽然是公会柜台小姐，但是因为讨厌加班所以要去单挑BOSS"
+			],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/3b9bade6-28a0-4f2f-8211-4b5106a2cbbd/guild-no-uketsukejou-desu-ga-zangyou-wa-iya-nanode-boss-wo-solo-toubatsu-shiyou-to-omoimasu"
+			],
+			"description": "\"It's safe because it's a desk job, super stable because it's public work!\"\n\nAlina Clover thought being a receptionist for the Adventurers Guild would be her ticket to the good life... but her dream gig turns into an overtime nightmare whenever adventurers get stuck clearing a dungeon. To save herself from paperwork, Alina turns to the simplest solution at hand — beating down the monsters herself! A mysterious adventurer showing up out of nowhere, soloing the boss, then disappearing without taking credit is bound to create rumors, and Alina's treasured job forbids side hustles. So there might be trouble when the leader of the Silver Sword party discovers her secret...!",
+			"publication": 2025,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-03-27T18:07:45.837Z",
+			"updatedAt": "2026-03-27T18:07:45.837Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "b68c149f-f46a-4b68-a47b-14cad69b37a7",
+					"url": "books/ab/ab43861c-4cbc-44be-a847-4d031b6b1a85.webp",
+					"title": "Volume 1",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:eec5862ca3ca31e6",
+						"width": 1800,
+						"height": 2560,
+						"entropy": 7.999147307127992,
+						"blurHash": "LJJa$Q~q?v%Lxbxbr=WT^QnTjwMy",
+						"mimeType": "image/webp",
+						"sizeBytes": 425362,
+						"formatOrigin": "webp",
+						"dominantColor": "#615A5F"
+					},
+					"imageHash": "395c702dd9a5be3e298122ceed62a8a803ab6fe0b052057c79282f40416ad4f5",
+					"originalUrl": "https://uploads.mangadex.org/covers/3b9bade6-28a0-4f2f-8211-4b5106a2cbbd/55148bdf-13bf-4aaa-899f-6cf8672c7a43.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/ab/ab43861c-4cbc-44be-a847-4d031b6b1a85.webp",
+			"coverMetadata": {
+				"pHash": "p:eec5862ca3ca31e6",
+				"width": 1800,
+				"height": 2560,
+				"entropy": 7.999147307127992,
+				"blurHash": "LJJa$Q~q?v%Lxbxbr=WT^QnTjwMy",
+				"mimeType": "image/webp",
+				"sizeBytes": 425362,
+				"formatOrigin": "webp",
+				"dominantColor": "#615A5F"
+			}
+		},
+		{
+			"id": "fe49288b-4e55-47dd-b6fa-89ee2995215d",
+			"title": "Boku no Ikezu na Konyakusha",
+			"alternativeTitle": [
+				"僕のいけずな婚約者",
+				"My Fiancée is so Mean!",
+				"Tunanganku yang jahil!",
+				"Moja Narzeczona jest strasznie Złośliwa!",
+				"Minha Noiva É Tão Maldosa!",
+				"My Teasing Fiancée"
+			],
+			"type": "manga",
+			"originalUrl": [
+				"https://mangadex.org/title/ead3f958-0d01-4c1f-b605-620eacb8ead0/boku-no-ikezu-na-konyakusha"
+			],
+			"description": "Miyuki-san is a young lady born in Kyoto. My relationship with her cannot be described as good. Because... \"You're very good at flattery.\" Are those words sincere? Or just for show?",
+			"publication": 2024,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": null,
+			"createdAt": "2026-03-27T15:37:45.785Z",
+			"updatedAt": "2026-03-27T15:37:45.785Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "d721edc2-248d-4585-826d-2d4382e32de3",
+					"url": "books/22/2227c938-8c03-411f-873f-698e8604da32.webp",
+					"title": "Volume 2",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:c829f77820576ecc",
+						"width": 1350,
+						"height": 1920,
+						"entropy": 7.998121946773184,
+						"blurHash": "LKIFGJ.7F|R+8^IAS~n#-;tPkXtS",
+						"mimeType": "image/webp",
+						"sizeBytes": 155756,
+						"formatOrigin": "webp",
+						"dominantColor": "#C0CAD9"
+					},
+					"imageHash": "d27f940f28da38aecbc2a1b647b12d794c823e6955f04a53e3b0bcbbf6232a4b",
+					"originalUrl": "https://uploads.mangadex.org/covers/ead3f958-0d01-4c1f-b605-620eacb8ead0/d808dc11-237f-4675-9f88-eb1d35573cd7.jpg",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/22/2227c938-8c03-411f-873f-698e8604da32.webp",
+			"coverMetadata": {
+				"pHash": "p:c829f77820576ecc",
+				"width": 1350,
+				"height": 1920,
+				"entropy": 7.998121946773184,
+				"blurHash": "LKIFGJ.7F|R+8^IAS~n#-;tPkXtS",
+				"mimeType": "image/webp",
+				"sizeBytes": 155756,
+				"formatOrigin": "webp",
+				"dominantColor": "#C0CAD9"
+			}
+		},
+		{
+			"id": "c0ea358a-7af5-4f2f-94e9-5bf1f534a6f8",
+			"title": "Zhan Long",
+			"alternativeTitle": ["Slaying Dragon, Trảm Long, 斩龙"],
+			"type": "book",
+			"originalUrl": ["https://centralnovel.com/series/zhan-long/"],
+			"description": "Descontente com o comando, Li Xiao Yao deixou a SWAT para ter uma vida normal. Trabalhou de segurança pessoal para pessoas importantes. Porém o destino resolveu dar-lhe uma lição e fazer uma reviravolta em sua vida.",
+			"publication": 2013,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": ["pdf"],
+			"createdAt": "2026-03-27T14:30:27.490Z",
+			"updatedAt": "2026-03-27T14:30:30.000Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "f402de6b-3d9c-4e6f-b7b1-84635630dc52",
+					"url": "books/8e/8e9592e7-f589-4823-b02c-c651735965c8.webp",
+					"title": "Capa",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:e136b24e976c8c8d",
+						"width": 370,
+						"height": 500,
+						"entropy": 7.990025256251478,
+						"blurHash": "LDKn@[.8uPoz9ZRP.SxuyES#-p%M",
+						"mimeType": "image/webp",
+						"sizeBytes": 20782,
+						"formatOrigin": "webp",
+						"dominantColor": "#B1C0C5"
+					},
+					"imageHash": "2e98ffcc0eadcdcbe2040ccd07b50c10db1877e6d2462d41bfe02f58c723b460",
+					"originalUrl": "https://i0.wp.com/centralnovel.com/wp-content/uploads/2021/11/Zhan-Long-CAPA.jpg?resize=370,500",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/8e/8e9592e7-f589-4823-b02c-c651735965c8.webp",
+			"coverMetadata": {
+				"pHash": "p:e136b24e976c8c8d",
+				"width": 370,
+				"height": 500,
+				"entropy": 7.990025256251478,
+				"blurHash": "LDKn@[.8uPoz9ZRP.SxuyES#-p%M",
+				"mimeType": "image/webp",
+				"sizeBytes": 20782,
+				"formatOrigin": "webp",
+				"dominantColor": "#B1C0C5"
+			}
+		},
+		{
+			"id": "032fca17-ef24-4383-b0e4-b700b345887c",
+			"title": "The New Gate",
+			"alternativeTitle": ["O Novo Portal, ONP, TNG, ザ・ニュー・ゲート"],
+			"type": "book",
+			"originalUrl": ["https://centralnovel.com/series/the-new-gate/"],
+			"description": "O Novo Portal — um jogo online transformado numa luta de vida ou morte para os seus jogadores. Graças aos valentes esforços de Shin, o mais poderoso de todos, o fim do jogo e a liberdade para todos pareciam estar ao alcance. Mas momentos depois de Shin derrotar o chefe final do jogo, dá por si banhado por uma luz desconhecida e transportado 500 anos para o futuro do mundo do jogo. Atirado de um simples jogo que correu mal para uma terra nova e estranha, um jovem espadachim de força inigualável está prestes a embarcar numa viagem lendária!",
+			"publication": 2013,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": ["pdf"],
+			"createdAt": "2026-03-27T14:25:41.600Z",
+			"updatedAt": "2026-03-27T14:25:44.000Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "b709d853-1706-4578-a5db-2c6117da0061",
+					"url": "books/05/05dd2b62-f8cb-4a50-88f6-03f45464a174.webp",
+					"title": "Capa",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:d4cc66c51f30137b",
+						"width": 370,
+						"height": 500,
+						"entropy": 7.99480477459638,
+						"blurHash": "LC9%*l$%DNR:?HbHM}V@Ius.tRWB",
+						"mimeType": "image/webp",
+						"sizeBytes": 33130,
+						"formatOrigin": "webp",
+						"dominantColor": "#354869"
+					},
+					"imageHash": "eb2a18d161f5c0d256846a005541c1cbb27495dd3f19b73a92771555c29ce29a",
+					"originalUrl": "https://i3.wp.com/centralnovel.com/wp-content/uploads/2025/08/The-New-Gate-capa.jpg?resize=370,500",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/05/05dd2b62-f8cb-4a50-88f6-03f45464a174.webp",
+			"coverMetadata": {
+				"pHash": "p:d4cc66c51f30137b",
+				"width": 370,
+				"height": 500,
+				"entropy": 7.99480477459638,
+				"blurHash": "LC9%*l$%DNR:?HbHM}V@Ius.tRWB",
+				"mimeType": "image/webp",
+				"sizeBytes": 33130,
+				"formatOrigin": "webp",
+				"dominantColor": "#354869"
+			}
+		},
+		{
+			"id": "92bddf75-f7f9-4b35-8b3e-c4cc8d392580",
+			"title": "Tales of Demons and Gods",
+			"alternativeTitle": [
+				"Contos de Demônios e Deuses, CDD, TDG, Yao Shen Ji, Yêu Thần Ký, 妖神记"
+			],
+			"type": "book",
+			"originalUrl": [
+				"https://centralnovel.com/series/tales-of-demons-and-gods-20241031/"
+			],
+			"description": "Nie Li, o mais forte Espiritualista Demoníaco, em sua vida passada, estava de pé no pináculo do mundo marcial. No entanto, ele perdeu sua vida durante a batalha contra o Sábio Imperador e suas seis Bestas Divinas. Sua alma, voltou no tempo, para quando ele ainda tinha apenas 13 anos. Embora ele fosse o mais fraco em sua classe, com o pior talento, e tivesse apenas um Reino da Alma Vermelho, com o auxílio do vasto conhecimento que havia acumulado em sua vida anterior, ele treinaria e se elevaria mais rápido que qualquer um. Desta vez, ele vai tentar proteger a Cidade da Gloria, que no futuro próximo, será atacada por bestas e poderá ser destruída, bem como proteger sua amada, amigos e familiares que morreram neste ataque em sua vida passada. Além de também destruir a Família Sagrada, que abandonou o seu dever e traiu a Cidade da Glória no momento em que ela mais precisava.",
+			"publication": 2015,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": ["pdf"],
+			"createdAt": "2026-03-27T14:24:02.232Z",
+			"updatedAt": "2026-03-27T14:24:05.000Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "fd64f34a-2187-4b97-8900-878cd3d077cb",
+					"url": "books/22/22ac1aaf-d8e2-44bf-b4a4-0d7293a7f6f2.webp",
+					"title": "Capa",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:adaec03bc9a8d616",
+						"width": 370,
+						"height": 500,
+						"entropy": 7.994759643185697,
+						"blurHash": "LJIOLn4UpHj{-rIqoaRPt0yDniD%",
+						"mimeType": "image/webp",
+						"sizeBytes": 40408,
+						"formatOrigin": "webp",
+						"dominantColor": "#CFD2D6"
+					},
+					"imageHash": "0c9dd21a9f3d1663940e42d9eadd27a78e265d88441f4be424ef9058abf204f3",
+					"originalUrl": "https://i1.wp.com/centralnovel.com/wp-content/uploads/2021/06/TDG-_CAPA_.jpg?resize=370,500",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/22/22ac1aaf-d8e2-44bf-b4a4-0d7293a7f6f2.webp",
+			"coverMetadata": {
+				"pHash": "p:adaec03bc9a8d616",
+				"width": 370,
+				"height": 500,
+				"entropy": 7.994759643185697,
+				"blurHash": "LJIOLn4UpHj{-rIqoaRPt0yDniD%",
+				"mimeType": "image/webp",
+				"sizeBytes": 40408,
+				"formatOrigin": "webp",
+				"dominantColor": "#CFD2D6"
+			}
+		},
+		{
+			"id": "553a0a3b-2840-413a-8e06-8c8d49845e86",
+			"title": "Seoul Station’s Necromancer",
+			"alternativeTitle": [
+				"NES, Necromante da Estação de Seul, SSN, 서울역 네크로맨서"
+			],
+			"type": "book",
+			"originalUrl": [
+				"https://centralnovel.com/series/seoul-stations-necromancer-20230928/"
+			],
+			"description": "Quando Kang Woojin, um ex-colegial, se vê de volta à Terra após ser, involuntariamente, invocado para um planeta desconhecido por 20 anos, logo descobre que seu planeta materno não era mais o mesmo que lembrara ser um dia.",
+			"publication": 2016,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": ["pdf"],
+			"createdAt": "2026-03-27T14:22:25.899Z",
+			"updatedAt": "2026-03-27T14:22:28.000Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "72c73f0c-7334-44df-8c08-c8d200815465",
+					"url": "books/63/634cf0f5-7374-4b14-990e-7b7deee8e04f.webp",
+					"title": "Capa",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:91a4ace938b23b76",
+						"width": 370,
+						"height": 500,
+						"entropy": 7.992462017800719,
+						"blurHash": "LC9P{8E1Wksr}]9tbqjv-pE3t6S0",
+						"mimeType": "image/webp",
+						"sizeBytes": 30284,
+						"formatOrigin": "webp",
+						"dominantColor": "#291E22"
+					},
+					"imageHash": "1b8a2cad8df4d62880642bff939326abf234996d99efc02d5b85f6e5583ca9e1",
+					"originalUrl": "https://i0.wp.com/centralnovel.com/wp-content/uploads/2021/06/Seoul-Stations-Necromancer-CAPA.jpg?resize=370,500",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/63/634cf0f5-7374-4b14-990e-7b7deee8e04f.webp",
+			"coverMetadata": {
+				"pHash": "p:91a4ace938b23b76",
+				"width": 370,
+				"height": 500,
+				"entropy": 7.992462017800719,
+				"blurHash": "LC9P{8E1Wksr}]9tbqjv-pE3t6S0",
+				"mimeType": "image/webp",
+				"sizeBytes": 30284,
+				"formatOrigin": "webp",
+				"dominantColor": "#291E22"
+			}
+		},
+		{
+			"id": "9315d6b4-2703-4eb2-a85b-d502244ffe8d",
+			"title": "Release that Witch - Novel",
+			"alternativeTitle": [
+				"Liberte Aquela Bruxa, Fàng kāi nàgè nǚwū, RTW, 放开那个女巫, 마녀 사용설명서"
+			],
+			"type": "book",
+			"originalUrl": [
+				"https://centralnovel.com/series/release-that-witch-20230516/"
+			],
+			"description": "Um engenheiro reencarnou em outro mundo e se tornou um príncipe. Esse lugar se assemelha muito à Idade Média Europeia, mas, ao mesmo tempo parece ser diferente. Bruxas existem de verdade e até mesmo possuem poderes mágicos! Poderes mágicos são forças de produção! Salvem as bruxas, libertem as forças de produção! Abram o mapa, lutem contra demônios, acabem com as conspirações, escalem a árvore da ciência e tecnologia e abram o caminho para o “farming hardcore”!",
+			"publication": 2016,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": ["pdf"],
+			"createdAt": "2026-03-27T14:19:10.887Z",
+			"updatedAt": "2026-03-27T14:19:14.000Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "effbc09d-f446-41b7-9ac5-dfc4632626e9",
+					"url": "books/b4/b43f0e3f-3e4f-486f-9677-6e8bbeb1e031.webp",
+					"title": "Capa",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:d1f496873cd38c34",
+						"width": 300,
+						"height": 400,
+						"entropy": 7.992466715076092,
+						"blurHash": "LeDmBd%LS5oz?wxaxat7%gjZjFoe",
+						"mimeType": "image/webp",
+						"sizeBytes": 28980,
+						"formatOrigin": "webp",
+						"dominantColor": "#D0D9D1"
+					},
+					"imageHash": "91ed915f7fe96be9279050cbb58be33a51635a58853c036d8cb7704234b86654",
+					"originalUrl": "https://centralnovel.com/wp-content/uploads/2021/06/Release-that-Witch-CAPA.webp",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/b4/b43f0e3f-3e4f-486f-9677-6e8bbeb1e031.webp",
+			"coverMetadata": {
+				"pHash": "p:d1f496873cd38c34",
+				"width": 300,
+				"height": 400,
+				"entropy": 7.992466715076092,
+				"blurHash": "LeDmBd%LS5oz?wxaxat7%gjZjFoe",
+				"mimeType": "image/webp",
+				"sizeBytes": 28980,
+				"formatOrigin": "webp",
+				"dominantColor": "#D0D9D1"
+			}
+		},
+		{
+			"id": "76b35d29-a16f-4a2d-b325-c30d1275d972",
+			"title": "Saijaku Muhai no Bahamut",
+			"alternativeTitle": [
+				"Crônicas do Bahamut Invicto, Undefeated Bahamut Chronicle, 最弱无败的神装机龙, 最弱無敗の神装機竜《バハムート》"
+			],
+			"type": "book",
+			"originalUrl": [
+				"https://centralnovel.com/series/saijaku-muhai-no-bahamut/"
+			],
+			"description": "Lux, que era um Príncipe do Império que foi destruído há cinco anos, encontrou-se com a Princesa do Novo Reino, Lisesharte, invadindo acidentalmente o banheiro do dormitório feminino.“……",
+			"publication": 2013,
+			"scrapingStatus": "ready",
+			"autoUpdate": false,
+			"availableFormats": ["pdf"],
+			"createdAt": "2026-03-27T10:30:03.384Z",
+			"updatedAt": "2026-03-27T10:30:06.000Z",
+			"deletedAt": null,
+			"covers": [
+				{
+					"id": "55e982a8-a9e5-43c3-835e-5fd396604716",
+					"url": "books/36/36996ea0-bba7-4df8-9699-30f8f338f191.webp",
+					"title": "Capa",
+					"index": 0,
+					"metadata": {
+						"pHash": "p:bec89618c7880ff6",
+						"width": 370,
+						"height": 500,
+						"entropy": 7.995136740760355,
+						"blurHash": "LJL4W+J~.T^k~B?bE3wb?]VFNx%1",
+						"mimeType": "image/webp",
+						"sizeBytes": 39284,
+						"formatOrigin": "webp",
+						"dominantColor": "#2E3E53"
+					},
+					"imageHash": "8280b5ef1a6fcf0badbf401ef26543396c0fe80d4835fd8ef7407aaa048eda33",
+					"originalUrl": "https://i0.wp.com/centralnovel.com/wp-content/uploads/2025/08/Saijaku-Muhai-no-Bahamut-capa.png?resize=370,500",
+					"selected": true,
+					"deletedAt": null
+				}
+			],
+			"cover": "https://s3-gatuno.canto.internal/books/36/36996ea0-bba7-4df8-9699-30f8f338f191.webp",
+			"coverMetadata": {
+				"pHash": "p:bec89618c7880ff6",
+				"width": 370,
+				"height": 500,
+				"entropy": 7.995136740760355,
+				"blurHash": "LJL4W+J~.T^k~B?bE3wb?]VFNx%1",
+				"mimeType": "image/webp",
+				"sizeBytes": 39284,
+				"formatOrigin": "webp",
+				"dominantColor": "#2E3E53"
+			}
+		}
+	],
+	"metadata": { "total": 131, "page": 1, "lastPage": 7 }
+}

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -15,6 +15,8 @@ import '../../features/settings/data/data_sources/settings_local_data_source.dar
 import '../../features/settings/domain/use_cases/settings_service.dart';
 import '../../features/certificates/certificates_injection.dart';
 import '../../features/certificates/domain/use_cases/certificates_service.dart';
+import '../image/image_loading_strategy.dart';
+import '../image/dio_image_loading_strategy.dart';
 
 final GetIt sl = GetIt.instance;
 
@@ -25,6 +27,9 @@ Future<void> initDI() async {
 
   sl.registerLazySingleton<DioClient>(
     () => DioClient(certificatesService: sl<CertificatesService>()),
+  );
+  sl.registerLazySingleton<ImageLoadingStrategy>(
+    () => DioImageLoadingStrategy(sl<DioClient>()),
   );
   sl.registerLazySingleton<SettingsStorage>(() => SettingsStorage());
   sl.registerLazySingleton<SettingsService>(

--- a/lib/core/image/dio_image_loading_strategy.dart
+++ b/lib/core/image/dio_image_loading_strategy.dart
@@ -1,0 +1,47 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+
+import '../logging/logger.dart';
+import '../network/dio_client.dart';
+import 'image_loading_strategy.dart';
+
+class DioImageLoadingStrategy implements ImageLoadingStrategy {
+  final DioClient _dioClient;
+
+  DioImageLoadingStrategy(this._dioClient);
+
+  @override
+  Future<Uint8List?> loadImage(
+    String url, {
+    void Function(Size)? onImageLoaded,
+  }) async {
+    try {
+      final response = await _dioClient.dio.get<List<int>>(
+        url,
+        options: Options(responseType: ResponseType.bytes),
+      );
+
+      if (response.data != null) {
+        final bytes = Uint8List.fromList(response.data!);
+
+        if (onImageLoaded != null) {
+          final buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
+          final descriptor = await ui.ImageDescriptor.encoded(buffer);
+          onImageLoaded(
+            Size(descriptor.width.toDouble(), descriptor.height.toDouble()),
+          );
+          descriptor.dispose();
+          buffer.dispose();
+        }
+
+        return bytes;
+      }
+    } catch (e, s) {
+      AppLogger.e('Error fetching image ($url)', e, s);
+    }
+    return null;
+  }
+}

--- a/lib/core/image/image_loading_strategy.dart
+++ b/lib/core/image/image_loading_strategy.dart
@@ -1,0 +1,9 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+
+abstract interface class ImageLoadingStrategy {
+  Future<Uint8List?> loadImage(
+    String url, {
+    void Function(Size)? onImageLoaded,
+  });
+}

--- a/lib/core/image/strategy_image_provider.dart
+++ b/lib/core/image/strategy_image_provider.dart
@@ -1,0 +1,69 @@
+import 'dart:ui' as ui;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'image_loading_strategy.dart';
+
+/// A custom [ImageProvider] that uses an [ImageLoadingStrategy] to fetch image bytes.
+///
+/// This allows integrating custom loading logic (like Dio-based fetching)
+/// directly into Flutter's image pipeline and caching system.
+class StrategyImageProvider extends ImageProvider<StrategyImageProvider> {
+  final String url;
+  final ImageLoadingStrategy strategy;
+  final void Function(Size)? onImageLoaded;
+
+  const StrategyImageProvider({
+    required this.url,
+    required this.strategy,
+    this.onImageLoaded,
+  });
+
+  @override
+  Future<StrategyImageProvider> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<StrategyImageProvider>(this);
+  }
+
+  @override
+  ImageStreamCompleter loadImage(
+    StrategyImageProvider key,
+    ImageDecoderCallback decode,
+  ) {
+    return MultiFrameImageStreamCompleter(
+      codec: _loadAsync(key, decode),
+      scale: 1.0,
+      debugLabel: key.url,
+      informationCollector:
+          () => <DiagnosticsNode>[
+            DiagnosticsProperty<ImageProvider>('Image provider', this),
+            DiagnosticsProperty<StrategyImageProvider>('Image key', key),
+          ],
+    );
+  }
+
+  Future<ui.Codec> _loadAsync(
+    StrategyImageProvider key,
+    ImageDecoderCallback decode,
+  ) async {
+    final bytes = await strategy.loadImage(url, onImageLoaded: onImageLoaded);
+    if (bytes == null || bytes.isEmpty) {
+      throw StateError('Failed to load image bytes from $url');
+    }
+    final buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
+    return decode(buffer);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) return false;
+    return other is StrategyImageProvider &&
+        other.url == url &&
+        other.strategy == strategy;
+  }
+
+  @override
+  int get hashCode => Object.hash(url, strategy);
+
+  @override
+  String toString() =>
+      '${objectRuntimeType(this, 'StrategyImageProvider')}(url: "$url", strategy: $strategy)';
+}

--- a/lib/features/books/data/models/book_model.dart
+++ b/lib/features/books/data/models/book_model.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import '../../../../shared/data/models/image_metadata_model.dart';
 import '../../domain/entities/book.dart';
 import '../../domain/entities/book_type.dart';
 import '../../domain/entities/author.dart';
@@ -63,6 +64,9 @@ class TypeBookConverter implements JsonConverter<TypeBook?, dynamic> {
   converters: [AuthorListConverter(), TagListConverter(), TypeBookConverter()],
 )
 class BookModel extends Book {
+  @JsonKey(name: 'coverMetadata')
+  final ImageMetadataModel? imageMetadata;
+
   const BookModel({
     required super.id,
     required super.title,
@@ -70,12 +74,13 @@ class BookModel extends Book {
     super.tags = const [],
     super.description,
     super.cover,
+    this.imageMetadata,
     super.type,
     super.publication,
     super.totalChapters,
     super.createdAt,
     super.updatedAt,
-  });
+  }) : super(metadata: imageMetadata);
 
   factory BookModel.fromJson(Map<String, dynamic> json) =>
       _$BookModelFromJson(json);

--- a/lib/features/books/data/models/book_model.g.dart
+++ b/lib/features/books/data/models/book_model.g.dart
@@ -17,6 +17,11 @@ BookModel _$BookModelFromJson(Map<String, dynamic> json) => BookModel(
       : const TagListConverter().fromJson(json['tags'] as List?),
   description: json['description'] as String?,
   cover: json['cover'] as String?,
+  imageMetadata: json['coverMetadata'] == null
+      ? null
+      : ImageMetadataModel.fromJson(
+          json['coverMetadata'] as Map<String, dynamic>,
+        ),
   type: const TypeBookConverter().fromJson(json['type']),
   publication: (json['publication'] as num?)?.toInt(),
   totalChapters: (json['totalChapters'] as num?)?.toInt(),
@@ -40,6 +45,7 @@ Map<String, dynamic> _$BookModelToJson(BookModel instance) => <String, dynamic>{
   'totalChapters': instance.totalChapters,
   'createdAt': instance.createdAt?.toIso8601String(),
   'updatedAt': instance.updatedAt?.toIso8601String(),
+  'coverMetadata': instance.imageMetadata?.toJson(),
 };
 
 BookListModel _$BookListModelFromJson(Map<String, dynamic> json) =>

--- a/lib/features/books/domain/entities/book.dart
+++ b/lib/features/books/domain/entities/book.dart
@@ -1,3 +1,4 @@
+import '../../../../shared/domain/entities/image_metadata.dart';
 import 'author.dart';
 import 'book_type.dart';
 import 'tag.dart';
@@ -9,6 +10,7 @@ class Book {
   final List<Tag> tags;
   final String? description;
   final String? cover;
+  final ImageMetadata? metadata;
   final TypeBook? type;
   final int? publication;
   final int? totalChapters;
@@ -22,6 +24,7 @@ class Book {
     this.tags = const [],
     this.description,
     this.cover,
+    this.metadata,
     this.type,
     this.publication,
     this.totalChapters,

--- a/lib/features/books/presentation/components/atoms/book_cover.dart
+++ b/lib/features/books/presentation/components/atoms/book_cover.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+
+import '../../../../../core/di/injection.dart';
+import '../../../../../core/image/image_loading_strategy.dart';
 import '../../../../../shared/components/atoms/app_image.dart';
 import '../../../../../shared/components/atoms/app_skeleton.dart';
 
@@ -31,6 +34,7 @@ class BookCover extends StatelessWidget {
     if (imageUrl != null) {
       content = AppImage(
         imageUrl: imageUrl!,
+        strategy: sl<ImageLoadingStrategy>(),
         blurHash: blurHash,
         width: width,
         height: height,

--- a/lib/features/books/presentation/components/atoms/book_cover.dart
+++ b/lib/features/books/presentation/components/atoms/book_cover.dart
@@ -4,6 +4,7 @@ import '../../../../../shared/components/atoms/app_skeleton.dart';
 
 class BookCover extends StatelessWidget {
   final String? imageUrl;
+  final String? blurHash;
   final double? width;
   final double? height;
   final BoxFit fit;
@@ -14,6 +15,7 @@ class BookCover extends StatelessWidget {
   const BookCover({
     super.key,
     this.imageUrl,
+    this.blurHash,
     this.width,
     this.height,
     this.fit = BoxFit.cover,
@@ -29,6 +31,7 @@ class BookCover extends StatelessWidget {
     if (imageUrl != null) {
       content = AppImage(
         imageUrl: imageUrl!,
+        blurHash: blurHash,
         width: width,
         height: height,
         fit: fit,

--- a/lib/features/books/presentation/components/atoms/book_cover_large.dart
+++ b/lib/features/books/presentation/components/atoms/book_cover_large.dart
@@ -3,12 +3,14 @@ import 'package:gatuno/features/books/presentation/components/atoms/book_cover.d
 
 class BookCoverLarge extends StatelessWidget {
   final String? coverUrl;
+  final String? blurHash;
   final double width;
   final double height;
 
   const BookCoverLarge({
     super.key,
     this.coverUrl,
+    this.blurHash,
     this.width = 240,
     this.height = 360,
   });
@@ -30,6 +32,7 @@ class BookCoverLarge extends StatelessWidget {
       ),
       child: BookCover(
         imageUrl: coverUrl,
+        blurHash: blurHash,
         width: width,
         height: height,
         borderRadius: 16,

--- a/lib/features/books/presentation/components/molecules/book_card.dart
+++ b/lib/features/books/presentation/components/molecules/book_card.dart
@@ -20,6 +20,7 @@ class BookCard extends StatelessWidget {
           children: [
             BookCover(
               imageUrl: book.cover,
+              blurHash: book.metadata?.blurHash,
               borderRadius: 0,
               iconSize: 60,
               usePlaceholderIfNull: true,

--- a/lib/features/books/presentation/components/molecules/book_list_item.dart
+++ b/lib/features/books/presentation/components/molecules/book_list_item.dart
@@ -22,7 +22,12 @@ class BookListItem extends StatelessWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              BookCover(imageUrl: book.cover, width: 70, height: 100),
+              BookCover(
+                imageUrl: book.cover,
+                blurHash: book.metadata?.blurHash,
+                width: 70,
+                height: 100,
+              ),
               const SizedBox(width: 16),
               Expanded(
                 child: BookInfo(

--- a/lib/features/books/presentation/components/organisms/book_details_content.dart
+++ b/lib/features/books/presentation/components/organisms/book_details_content.dart
@@ -33,7 +33,10 @@ class BookDetailsContent extends StatelessWidget {
           onPressed: () => context.pop(),
         ),
       ),
-      cover: BookCoverLarge(coverUrl: book.cover),
+      cover: BookCoverLarge(
+        coverUrl: book.cover,
+        blurHash: book.metadata?.blurHash,
+      ),
       header: BookDetailsHeader(
         title: book.title,
         authors: book.authors,

--- a/lib/features/reading/data/models/reading_chapter_model.dart
+++ b/lib/features/reading/data/models/reading_chapter_model.dart
@@ -3,6 +3,8 @@ import '../../domain/entities/reading_chapter.dart';
 import '../../domain/entities/reading_enums.dart';
 import '../../../books/domain/entities/chapter.dart';
 
+import '../../../../shared/data/models/image_metadata_model.dart';
+
 part 'reading_chapter_model.g.dart';
 
 class IntConverter implements JsonConverter<int, dynamic> {
@@ -81,14 +83,14 @@ class ScrapingStatusConverter
 @JsonSerializable(converters: [IntConverter(), StringConverter()])
 class ReadingPageModel extends ReadingPage {
   @JsonKey(name: 'metadata')
-  final PageMetadataModel? pageMetadata;
+  final ImageMetadataModel? imageMetadata;
 
   ReadingPageModel({
     required super.id,
     @JsonKey(readValue: _readUrl) required super.url,
     required super.index,
-    this.pageMetadata,
-  }) : super(width: pageMetadata?.width, height: pageMetadata?.height);
+    this.imageMetadata,
+  }) : super(metadata: imageMetadata);
 
   factory ReadingPageModel.fromJson(Map<String, dynamic> json) =>
       _$ReadingPageModelFromJson(json);
@@ -97,19 +99,6 @@ class ReadingPageModel extends ReadingPage {
 
   static Object? _readUrl(Map<dynamic, dynamic> json, String key) =>
       json['path'] ?? json['url'] ?? '';
-}
-
-@JsonSerializable(converters: [DoubleConverter()])
-class PageMetadataModel {
-  final double width;
-  final double height;
-
-  const PageMetadataModel({required this.width, required this.height});
-
-  factory PageMetadataModel.fromJson(Map<String, dynamic> json) =>
-      _$PageMetadataModelFromJson(json);
-
-  Map<String, dynamic> toJson() => _$PageMetadataModelToJson(this);
 }
 
 @JsonSerializable(converters: [StringConverter()])

--- a/lib/features/reading/data/models/reading_chapter_model.g.dart
+++ b/lib/features/reading/data/models/reading_chapter_model.g.dart
@@ -12,9 +12,9 @@ ReadingPageModel _$ReadingPageModelFromJson(
   id: const StringConverter().fromJson(json['id']),
   url: const StringConverter().fromJson(ReadingPageModel._readUrl(json, 'url')),
   index: const IntConverter().fromJson(json['index']),
-  pageMetadata: json['metadata'] == null
+  imageMetadata: json['metadata'] == null
       ? null
-      : PageMetadataModel.fromJson(json['metadata'] as Map<String, dynamic>),
+      : ImageMetadataModel.fromJson(json['metadata'] as Map<String, dynamic>),
 );
 
 Map<String, dynamic> _$ReadingPageModelToJson(ReadingPageModel instance) =>
@@ -22,19 +22,7 @@ Map<String, dynamic> _$ReadingPageModelToJson(ReadingPageModel instance) =>
       'id': const StringConverter().toJson(instance.id),
       'url': const StringConverter().toJson(instance.url),
       'index': const IntConverter().toJson(instance.index),
-      'metadata': instance.pageMetadata,
-    };
-
-PageMetadataModel _$PageMetadataModelFromJson(Map<String, dynamic> json) =>
-    PageMetadataModel(
-      width: const DoubleConverter().fromJson(json['width']),
-      height: const DoubleConverter().fromJson(json['height']),
-    );
-
-Map<String, dynamic> _$PageMetadataModelToJson(PageMetadataModel instance) =>
-    <String, dynamic>{
-      'width': const DoubleConverter().toJson(instance.width),
-      'height': const DoubleConverter().toJson(instance.height),
+      'metadata': instance.imageMetadata,
     };
 
 ChapterCommentModel _$ChapterCommentModelFromJson(Map<String, dynamic> json) =>

--- a/lib/features/reading/domain/entities/reading_chapter.dart
+++ b/lib/features/reading/domain/entities/reading_chapter.dart
@@ -1,3 +1,4 @@
+import '../../../../shared/domain/entities/image_metadata.dart';
 import 'reading_enums.dart';
 import '../../../../features/books/domain/entities/chapter.dart';
 
@@ -5,16 +6,17 @@ class ReadingPage {
   final String id;
   final String url;
   final int index;
-  final double? width;
-  final double? height;
+  final ImageMetadata? metadata;
 
   const ReadingPage({
     required this.id,
     required this.url,
     required this.index,
-    this.width,
-    this.height,
+    this.metadata,
   });
+
+  double? get width => metadata?.width;
+  double? get height => metadata?.height;
 }
 
 class ChapterComment {

--- a/lib/features/reading/presentation/components/molecules/image_reader_item.dart
+++ b/lib/features/reading/presentation/components/molecules/image_reader_item.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+
+import '../../../../../core/di/injection.dart';
+import '../../../../../core/image/image_loading_strategy.dart';
 import '../../../../../shared/components/atoms/app_image.dart';
 import '../../../../../shared/utils/image_aspect_ratio_cache.dart';
 import '../../../domain/entities/reading_chapter.dart';
@@ -68,6 +71,7 @@ class _ImageReaderItemState extends State<ImageReaderItem> {
       aspectRatio: _aspectRatio,
       child: AppImage(
         imageUrl: widget.page.url,
+        strategy: sl<ImageLoadingStrategy>(),
         blurHash: widget.page.metadata?.blurHash,
         fit: BoxFit.fill,
         width: double.infinity,

--- a/lib/features/reading/presentation/components/molecules/image_reader_item.dart
+++ b/lib/features/reading/presentation/components/molecules/image_reader_item.dart
@@ -68,7 +68,8 @@ class _ImageReaderItemState extends State<ImageReaderItem> {
       aspectRatio: _aspectRatio,
       child: AppImage(
         imageUrl: widget.page.url,
-        fit: BoxFit.contain,
+        blurHash: widget.page.metadata?.blurHash,
+        fit: BoxFit.fill,
         width: double.infinity,
         onImageLoaded: _onImageLoaded,
         placeholder: const Center(child: CircularProgressIndicator()),

--- a/lib/features/reading/presentation/components/molecules/image_reader_item.dart
+++ b/lib/features/reading/presentation/components/molecules/image_reader_item.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../../../core/di/injection.dart';
 import '../../../../../core/image/image_loading_strategy.dart';
 import '../../../../../shared/components/atoms/app_image.dart';
+import '../../../../../shared/components/atoms/app_loading_indicator.dart';
 import '../../../../../shared/utils/image_aspect_ratio_cache.dart';
 import '../../../domain/entities/reading_chapter.dart';
 
@@ -76,7 +77,7 @@ class _ImageReaderItemState extends State<ImageReaderItem> {
         fit: BoxFit.fill,
         width: double.infinity,
         onImageLoaded: _onImageLoaded,
-        placeholder: const Center(child: CircularProgressIndicator()),
+        placeholder: const Center(child: AppLoadingIndicator()),
       ),
     );
   }

--- a/lib/shared/components/atoms/app_image.dart
+++ b/lib/shared/components/atoms/app_image.dart
@@ -35,6 +35,7 @@ class AppImage extends StatefulWidget {
 
 class _AppImageState extends State<AppImage> {
   late Future<Uint8List?> _fetchFuture;
+  static const _placeholderKey = ValueKey('app_image_placeholder');
 
   @override
   void initState() {
@@ -67,7 +68,7 @@ class _AppImageState extends State<AppImage> {
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return AppImagePlaceholder(
-            key: const ValueKey('waiting'),
+            key: _placeholderKey,
             blurHash: widget.blurHash,
             width: widget.width,
             height: widget.height,
@@ -107,6 +108,19 @@ class _AppImageState extends State<AppImage> {
           frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
             if (wasSynchronouslyLoaded) return child;
 
+            if (widget.blurHash == null) {
+              if (frame == null) {
+                return AppImagePlaceholder(
+                  key: _placeholderKey,
+                  blurHash: widget.blurHash,
+                  width: widget.width,
+                  height: widget.height,
+                  placeholder: widget.placeholder,
+                );
+              }
+              return child;
+            }
+
             return Stack(
               fit: StackFit.passthrough,
               alignment: Alignment.center,
@@ -116,7 +130,7 @@ class _AppImageState extends State<AppImage> {
                   duration: const Duration(milliseconds: 600),
                   curve: const Interval(0.5, 1.0, curve: Curves.easeOut),
                   child: AppImagePlaceholder(
-                    key: const ValueKey('placeholder'),
+                    key: _placeholderKey,
                     blurHash: widget.blurHash,
                     width: widget.width,
                     height: widget.height,

--- a/lib/shared/components/atoms/app_image.dart
+++ b/lib/shared/components/atoms/app_image.dart
@@ -2,12 +2,14 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_blurhash/flutter_blurhash.dart';
 import '../../../core/di/injection.dart';
 import '../../../core/network/dio_client.dart';
 import 'app_skeleton.dart';
 
 class AppImage extends StatefulWidget {
   final String imageUrl;
+  final String? blurHash;
   final double? width;
   final double? height;
   final BoxFit fit;
@@ -18,6 +20,7 @@ class AppImage extends StatefulWidget {
   const AppImage({
     super.key,
     required this.imageUrl,
+    this.blurHash,
     this.width,
     this.height,
     this.fit = BoxFit.cover,
@@ -78,17 +81,49 @@ class _AppImageState extends State<AppImage> {
     return null;
   }
 
+  Widget _buildPlaceholder({Key? key}) {
+    if (widget.blurHash != null) {
+      final blurHashWidget = BlurHash(
+        hash: widget.blurHash!,
+        imageFit: BoxFit.fill,
+      );
+
+      if (widget.width != null || widget.height != null) {
+        return SizedBox(
+          key: key,
+          width: widget.width,
+          height: widget.height,
+          child: blurHashWidget,
+        );
+      }
+
+      return KeyedSubtree(key: key, child: blurHashWidget);
+    }
+
+    return SizedBox(
+      key: key,
+      width: widget.width,
+      height: widget.height,
+      child:
+          widget.placeholder ??
+          AppSkeleton(width: widget.width, height: widget.height),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<Uint8List?>(
       future: _fetchFuture,
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return widget.placeholder ??
-              AppSkeleton(width: widget.width, height: widget.height);
+          return _buildPlaceholder(key: const ValueKey('waiting'));
         }
 
         if (snapshot.hasError || !snapshot.hasData || snapshot.data == null) {
+          if (widget.blurHash != null && widget.errorWidget == null) {
+            return _buildPlaceholder(key: const ValueKey('error'));
+          }
+
           return SizedBox(
             width: widget.width,
             height: widget.height,
@@ -106,12 +141,31 @@ class _AppImageState extends State<AppImage> {
           width: widget.width,
           height: widget.height,
           fit: widget.fit,
-          errorBuilder: (context, error, stackTrace) {
-            return Center(
-              child:
-                  widget.errorWidget ??
-                  const Icon(Icons.broken_image, size: 24.0),
+          gaplessPlayback: true,
+          frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+            if (wasSynchronouslyLoaded) return child;
+
+            return Stack(
+              fit: StackFit.passthrough,
+              alignment: Alignment.center,
+              children: [
+                AnimatedOpacity(
+                  opacity: frame == null ? 1.0 : 0.0,
+                  duration: const Duration(milliseconds: 600),
+                  curve: const Interval(0.5, 1.0, curve: Curves.easeOut),
+                  child: _buildPlaceholder(key: const ValueKey('placeholder')),
+                ),
+                AnimatedOpacity(
+                  opacity: frame == null ? 0.0 : 1.0,
+                  duration: const Duration(milliseconds: 600),
+                  curve: const Interval(0.0, 0.5, curve: Curves.easeIn),
+                  child: child,
+                ),
+              ],
             );
+          },
+          errorBuilder: (context, error, stackTrace) {
+            return _buildPlaceholder(key: const ValueKey('error'));
           },
         );
       },

--- a/lib/shared/components/atoms/app_image.dart
+++ b/lib/shared/components/atoms/app_image.dart
@@ -1,11 +1,9 @@
 import 'dart:typed_data';
-import 'dart:ui' as ui;
-import 'package:dio/dio.dart';
+
 import 'package:flutter/material.dart';
-import 'package:flutter_blurhash/flutter_blurhash.dart';
-import '../../../core/di/injection.dart';
-import '../../../core/network/dio_client.dart';
-import 'app_skeleton.dart';
+
+import '../../../../core/image/image_loading_strategy.dart';
+import 'app_image_placeholder.dart';
 
 class AppImage extends StatefulWidget {
   final String imageUrl;
@@ -16,10 +14,12 @@ class AppImage extends StatefulWidget {
   final Widget? placeholder;
   final Widget? errorWidget;
   final void Function(Size)? onImageLoaded;
+  final ImageLoadingStrategy strategy;
 
   const AppImage({
     super.key,
     required this.imageUrl,
+    required this.strategy,
     this.blurHash,
     this.width,
     this.height,
@@ -35,7 +35,6 @@ class AppImage extends StatefulWidget {
 
 class _AppImageState extends State<AppImage> {
   late Future<Uint8List?> _fetchFuture;
-  final _dioClient = sl<DioClient>();
 
   @override
   void initState() {
@@ -46,67 +45,18 @@ class _AppImageState extends State<AppImage> {
   @override
   void didUpdateWidget(AppImage oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.imageUrl != widget.imageUrl) {
+    if (oldWidget.imageUrl != widget.imageUrl ||
+        oldWidget.strategy != widget.strategy) {
       setState(() {
         _fetchFuture = _fetchImage();
       });
     }
   }
 
-  Future<Uint8List?> _fetchImage() async {
-    try {
-      final response = await _dioClient.dio.get<List<int>>(
-        widget.imageUrl,
-        options: Options(responseType: ResponseType.bytes),
-      );
-
-      if (response.data != null) {
-        final bytes = Uint8List.fromList(response.data!);
-
-        if (widget.onImageLoaded != null) {
-          final buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
-          final descriptor = await ui.ImageDescriptor.encoded(buffer);
-          widget.onImageLoaded!(
-            Size(descriptor.width.toDouble(), descriptor.height.toDouble()),
-          );
-          descriptor.dispose();
-          buffer.dispose();
-        }
-
-        return bytes;
-      }
-    } catch (e) {
-      debugPrint('Error fetching image (${widget.imageUrl}): $e');
-    }
-    return null;
-  }
-
-  Widget _buildPlaceholder({Key? key}) {
-    if (widget.blurHash != null) {
-      final blurHashWidget = BlurHash(
-        hash: widget.blurHash!,
-        imageFit: BoxFit.fill,
-      );
-
-      if (widget.width != null || widget.height != null) {
-        return SizedBox(
-          key: key,
-          width: widget.width,
-          height: widget.height,
-          child: blurHashWidget,
-        );
-      }
-
-      return KeyedSubtree(key: key, child: blurHashWidget);
-    }
-
-    return SizedBox(
-      key: key,
-      width: widget.width,
-      height: widget.height,
-      child:
-          widget.placeholder ??
-          AppSkeleton(width: widget.width, height: widget.height),
+  Future<Uint8List?> _fetchImage() {
+    return widget.strategy.loadImage(
+      widget.imageUrl,
+      onImageLoaded: widget.onImageLoaded,
     );
   }
 
@@ -116,12 +66,24 @@ class _AppImageState extends State<AppImage> {
       future: _fetchFuture,
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return _buildPlaceholder(key: const ValueKey('waiting'));
+          return AppImagePlaceholder(
+            key: const ValueKey('waiting'),
+            blurHash: widget.blurHash,
+            width: widget.width,
+            height: widget.height,
+            placeholder: widget.placeholder,
+          );
         }
 
         if (snapshot.hasError || !snapshot.hasData || snapshot.data == null) {
           if (widget.blurHash != null && widget.errorWidget == null) {
-            return _buildPlaceholder(key: const ValueKey('error'));
+            return AppImagePlaceholder(
+              key: const ValueKey('error'),
+              blurHash: widget.blurHash,
+              width: widget.width,
+              height: widget.height,
+              placeholder: widget.placeholder,
+            );
           }
 
           return SizedBox(
@@ -153,7 +115,13 @@ class _AppImageState extends State<AppImage> {
                   opacity: frame == null ? 1.0 : 0.0,
                   duration: const Duration(milliseconds: 600),
                   curve: const Interval(0.5, 1.0, curve: Curves.easeOut),
-                  child: _buildPlaceholder(key: const ValueKey('placeholder')),
+                  child: AppImagePlaceholder(
+                    key: const ValueKey('placeholder'),
+                    blurHash: widget.blurHash,
+                    width: widget.width,
+                    height: widget.height,
+                    placeholder: widget.placeholder,
+                  ),
                 ),
                 AnimatedOpacity(
                   opacity: frame == null ? 0.0 : 1.0,
@@ -165,7 +133,13 @@ class _AppImageState extends State<AppImage> {
             );
           },
           errorBuilder: (context, error, stackTrace) {
-            return _buildPlaceholder(key: const ValueKey('error'));
+            return AppImagePlaceholder(
+              key: const ValueKey('error'),
+              blurHash: widget.blurHash,
+              width: widget.width,
+              height: widget.height,
+              placeholder: widget.placeholder,
+            );
           },
         );
       },

--- a/lib/shared/components/atoms/app_image.dart
+++ b/lib/shared/components/atoms/app_image.dart
@@ -1,11 +1,14 @@
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
 
 import '../../../../core/image/image_loading_strategy.dart';
+import '../../../../core/image/strategy_image_provider.dart';
 import 'app_image_placeholder.dart';
 
-class AppImage extends StatefulWidget {
+/// A widget that displays an image using a custom [ImageLoadingStrategy].
+///
+/// It handles placeholders, error states, and smooth transitions (fading)
+/// between the placeholder/blurhash and the final image.
+class AppImage extends StatelessWidget {
   final String imageUrl;
   final String? blurHash;
   final double? width;
@@ -30,133 +33,137 @@ class AppImage extends StatefulWidget {
   });
 
   @override
-  State<AppImage> createState() => _AppImageState();
-}
-
-class _AppImageState extends State<AppImage> {
-  late Future<Uint8List?> _fetchFuture;
-  static const _placeholderKey = ValueKey('app_image_placeholder');
-
-  @override
-  void initState() {
-    super.initState();
-    _fetchFuture = _fetchImage();
-  }
-
-  @override
-  void didUpdateWidget(AppImage oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.imageUrl != widget.imageUrl ||
-        oldWidget.strategy != widget.strategy) {
-      setState(() {
-        _fetchFuture = _fetchImage();
-      });
-    }
-  }
-
-  Future<Uint8List?> _fetchImage() {
-    return widget.strategy.loadImage(
-      widget.imageUrl,
-      onImageLoaded: widget.onImageLoaded,
+  Widget build(BuildContext context) {
+    return Image(
+      image: StrategyImageProvider(
+        url: imageUrl,
+        strategy: strategy,
+        onImageLoaded: onImageLoaded,
+      ),
+      width: width,
+      height: height,
+      fit: fit,
+      gaplessPlayback: true,
+      frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+        return _AppImagePresenter(
+          frame: frame,
+          wasSynchronouslyLoaded: wasSynchronouslyLoaded,
+          blurHash: blurHash,
+          width: width,
+          height: height,
+          placeholder: placeholder,
+          child: child,
+        );
+      },
+      errorBuilder: (context, error, stackTrace) {
+        return _AppImageErrorPresenter(
+          blurHash: blurHash,
+          width: width,
+          height: height,
+          placeholder: placeholder,
+          errorWidget: errorWidget,
+        );
+      },
     );
   }
+}
+
+class _AppImagePresenter extends StatelessWidget {
+  final int? frame;
+  final bool wasSynchronouslyLoaded;
+  final String? blurHash;
+  final double? width;
+  final double? height;
+  final Widget? placeholder;
+  final Widget child;
+
+  const _AppImagePresenter({
+    required this.frame,
+    required this.wasSynchronouslyLoaded,
+    required this.blurHash,
+    required this.width,
+    required this.height,
+    required this.placeholder,
+    required this.child,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<Uint8List?>(
-      future: _fetchFuture,
-      builder: (context, snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting) {
-          return AppImagePlaceholder(
-            key: _placeholderKey,
-            blurHash: widget.blurHash,
-            width: widget.width,
-            height: widget.height,
-            placeholder: widget.placeholder,
-          );
-        }
+    if (wasSynchronouslyLoaded) return child;
 
-        if (snapshot.hasError || !snapshot.hasData || snapshot.data == null) {
-          if (widget.blurHash != null && widget.errorWidget == null) {
-            return AppImagePlaceholder(
-              key: const ValueKey('error'),
-              blurHash: widget.blurHash,
-              width: widget.width,
-              height: widget.height,
-              placeholder: widget.placeholder,
-            );
-          }
-
-          return SizedBox(
-            width: widget.width,
-            height: widget.height,
-            child: Center(
-              child:
-                  widget.errorWidget ??
-                  widget.placeholder ??
-                  const Icon(Icons.broken_image, size: 24.0),
-            ),
-          );
-        }
-
-        return Image.memory(
-          snapshot.data!,
-          width: widget.width,
-          height: widget.height,
-          fit: widget.fit,
-          gaplessPlayback: true,
-          frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
-            if (wasSynchronouslyLoaded) return child;
-
-            if (widget.blurHash == null) {
-              if (frame == null) {
-                return AppImagePlaceholder(
-                  key: _placeholderKey,
-                  blurHash: widget.blurHash,
-                  width: widget.width,
-                  height: widget.height,
-                  placeholder: widget.placeholder,
-                );
-              }
-              return child;
-            }
-
-            return Stack(
-              fit: StackFit.passthrough,
-              alignment: Alignment.center,
-              children: [
-                AnimatedOpacity(
-                  opacity: frame == null ? 1.0 : 0.0,
-                  duration: const Duration(milliseconds: 600),
-                  curve: const Interval(0.5, 1.0, curve: Curves.easeOut),
-                  child: AppImagePlaceholder(
-                    key: _placeholderKey,
-                    blurHash: widget.blurHash,
-                    width: widget.width,
-                    height: widget.height,
-                    placeholder: widget.placeholder,
-                  ),
-                ),
-                AnimatedOpacity(
-                  opacity: frame == null ? 0.0 : 1.0,
-                  duration: const Duration(milliseconds: 600),
-                  curve: const Interval(0.0, 0.5, curve: Curves.easeIn),
-                  child: child,
-                ),
-              ],
-            );
-          },
-          errorBuilder: (context, error, stackTrace) {
-            return AppImagePlaceholder(
-              key: const ValueKey('error'),
-              blurHash: widget.blurHash,
-              width: widget.width,
-              height: widget.height,
-              placeholder: widget.placeholder,
-            );
-          },
+    if (blurHash == null) {
+      if (frame == null) {
+        return AppImagePlaceholder(
+          blurHash: blurHash,
+          width: width,
+          height: height,
+          placeholder: placeholder,
         );
-      },
+      }
+      return child;
+    }
+
+    return Stack(
+      fit: StackFit.passthrough,
+      alignment: Alignment.center,
+      children: [
+        AnimatedOpacity(
+          opacity: frame == null ? 1.0 : 0.0,
+          duration: const Duration(milliseconds: 600),
+          curve: const Interval(0.5, 1.0, curve: Curves.easeOut),
+          child: AppImagePlaceholder(
+            blurHash: blurHash,
+            width: width,
+            height: height,
+            placeholder: placeholder,
+          ),
+        ),
+        AnimatedOpacity(
+          opacity: frame == null ? 0.0 : 1.0,
+          duration: const Duration(milliseconds: 600),
+          curve: const Interval(0.0, 0.5, curve: Curves.easeIn),
+          child: child,
+        ),
+      ],
+    );
+  }
+}
+
+class _AppImageErrorPresenter extends StatelessWidget {
+  final String? blurHash;
+  final double? width;
+  final double? height;
+  final Widget? placeholder;
+  final Widget? errorWidget;
+
+  const _AppImageErrorPresenter({
+    required this.blurHash,
+    required this.width,
+    required this.height,
+    required this.placeholder,
+    required this.errorWidget,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (blurHash != null && errorWidget == null) {
+      return AppImagePlaceholder(
+        blurHash: blurHash,
+        width: width,
+        height: height,
+        placeholder: placeholder,
+      );
+    }
+
+    return SizedBox(
+      width: width,
+      height: height,
+      child: Center(
+        child:
+            errorWidget ??
+            placeholder ??
+            const Icon(Icons.broken_image, size: 24.0),
+      ),
     );
   }
 }

--- a/lib/shared/components/atoms/app_image_placeholder.dart
+++ b/lib/shared/components/atoms/app_image_placeholder.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_blurhash/flutter_blurhash.dart';
+
+import 'app_skeleton.dart';
+
+class AppImagePlaceholder extends StatelessWidget {
+  final String? blurHash;
+  final double? width;
+  final double? height;
+  final Widget? placeholder;
+
+  const AppImagePlaceholder({
+    super.key,
+    this.blurHash,
+    this.width,
+    this.height,
+    this.placeholder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (blurHash != null) {
+      final blurHashWidget = BlurHash(hash: blurHash!, imageFit: BoxFit.fill);
+
+      if (width != null || height != null) {
+        return SizedBox(width: width, height: height, child: blurHashWidget);
+      }
+
+      return blurHashWidget;
+    }
+
+    return SizedBox(
+      width: width,
+      height: height,
+      child: placeholder ?? AppSkeleton(width: width, height: height),
+    );
+  }
+}

--- a/lib/shared/data/models/image_metadata_model.dart
+++ b/lib/shared/data/models/image_metadata_model.dart
@@ -1,0 +1,33 @@
+import 'package:json_annotation/json_annotation.dart';
+import '../../domain/entities/image_metadata.dart';
+
+part 'image_metadata_model.g.dart';
+
+class DoubleConverter implements JsonConverter<double, dynamic> {
+  const DoubleConverter();
+  @override
+  double fromJson(dynamic json) =>
+      double.tryParse(json?.toString() ?? '0') ?? 0.0;
+  @override
+  dynamic toJson(double object) => object;
+}
+
+@JsonSerializable(converters: [DoubleConverter()])
+class ImageMetadataModel extends ImageMetadata {
+  const ImageMetadataModel({
+    required super.width,
+    required super.height,
+    super.sizeBytes,
+    super.mimeType,
+    super.blurHash,
+    super.dominantColor,
+    super.pHash,
+    super.entropy,
+    super.formatOrigin,
+  });
+
+  factory ImageMetadataModel.fromJson(Map<String, dynamic> json) =>
+      _$ImageMetadataModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ImageMetadataModelToJson(this);
+}

--- a/lib/shared/data/models/image_metadata_model.g.dart
+++ b/lib/shared/data/models/image_metadata_model.g.dart
@@ -1,0 +1,41 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'image_metadata_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ImageMetadataModel _$ImageMetadataModelFromJson(Map<String, dynamic> json) =>
+    ImageMetadataModel(
+      width: const DoubleConverter().fromJson(json['width']),
+      height: const DoubleConverter().fromJson(json['height']),
+      sizeBytes: (json['sizeBytes'] as num?)?.toInt(),
+      mimeType: json['mimeType'] as String?,
+      blurHash: json['blurHash'] as String?,
+      dominantColor: json['dominantColor'] as String?,
+      pHash: json['pHash'] as String?,
+      entropy: const DoubleConverter().fromJson(json['entropy']),
+      formatOrigin: json['formatOrigin'] as String?,
+    );
+
+Map<String, dynamic> _$ImageMetadataModelToJson(ImageMetadataModel instance) =>
+    <String, dynamic>{
+      'width': const DoubleConverter().toJson(instance.width),
+      'height': const DoubleConverter().toJson(instance.height),
+      'sizeBytes': instance.sizeBytes,
+      'mimeType': instance.mimeType,
+      'blurHash': instance.blurHash,
+      'dominantColor': instance.dominantColor,
+      'pHash': instance.pHash,
+      'entropy': _$JsonConverterToJson<dynamic, double>(
+        instance.entropy,
+        const DoubleConverter().toJson,
+      ),
+      'formatOrigin': instance.formatOrigin,
+    };
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) => value == null ? null : toJson(value);

--- a/lib/shared/domain/entities/image_metadata.dart
+++ b/lib/shared/domain/entities/image_metadata.dart
@@ -1,0 +1,23 @@
+class ImageMetadata {
+  final double width;
+  final double height;
+  final int? sizeBytes;
+  final String? mimeType;
+  final String? blurHash;
+  final String? dominantColor;
+  final String? pHash;
+  final double? entropy;
+  final String? formatOrigin;
+
+  const ImageMetadata({
+    required this.width,
+    required this.height,
+    this.sizeBytes,
+    this.mimeType,
+    this.blurHash,
+    this.dominantColor,
+    this.pHash,
+    this.entropy,
+    this.formatOrigin,
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -294,6 +294,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_blurhash:
+    dependency: "direct main"
+    description:
+      name: flutter_blurhash
+      sha256: e97b9aff13b9930bbaa74d0d899fec76e3f320aba3190322dcc5d32104e3d25d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1"
   flutter_html:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   json_annotation: ^4.11.0
   file_picker: ^11.0.2
   crypto: ^3.0.7
+  flutter_blurhash: ^0.9.1
 
 dev_dependencies:
   flutter_test:

--- a/test/features/books/presentation/components/molecules/book_card_test.dart
+++ b/test/features/books/presentation/components/molecules/book_card_test.dart
@@ -7,6 +7,8 @@ import 'package:gatuno/features/books/presentation/components/molecules/book_car
 import 'package:gatuno/features/books/presentation/components/atoms/book_cover.dart';
 import 'package:gatuno/features/books/presentation/components/atoms/book_title.dart';
 import 'package:gatuno/core/di/injection.dart';
+import 'package:gatuno/core/image/dio_image_loading_strategy.dart';
+import 'package:gatuno/core/image/image_loading_strategy.dart';
 import 'package:gatuno/core/network/dio_client.dart';
 import 'package:mocktail/mocktail.dart';
 import '../../../../../helpers/pump_app.dart';
@@ -40,11 +42,22 @@ void main() {
     if (sl.isRegistered<DioClient>()) {
       sl.unregister<DioClient>();
     }
+    if (sl.isRegistered<ImageLoadingStrategy>()) {
+      sl.unregister<ImageLoadingStrategy>();
+    }
     sl.registerSingleton<DioClient>(mockDioClient);
+    sl.registerSingleton<ImageLoadingStrategy>(
+      DioImageLoadingStrategy(mockDioClient),
+    );
   });
 
   tearDown(() {
-    sl.unregister<DioClient>();
+    if (sl.isRegistered<DioClient>()) {
+      sl.unregister<DioClient>();
+    }
+    if (sl.isRegistered<ImageLoadingStrategy>()) {
+      sl.unregister<ImageLoadingStrategy>();
+    }
   });
 
   final testBook = Book(

--- a/test/features/books/presentation/components/molecules/book_list_item_test.dart
+++ b/test/features/books/presentation/components/molecules/book_list_item_test.dart
@@ -7,6 +7,8 @@ import 'package:gatuno/features/books/presentation/components/molecules/book_lis
 import 'package:gatuno/features/books/presentation/components/molecules/book_info.dart';
 import 'package:gatuno/features/books/presentation/components/atoms/book_cover.dart';
 import 'package:gatuno/core/di/injection.dart';
+import 'package:gatuno/core/image/dio_image_loading_strategy.dart';
+import 'package:gatuno/core/image/image_loading_strategy.dart';
 import 'package:gatuno/core/network/dio_client.dart';
 import 'package:mocktail/mocktail.dart';
 import '../../../../../helpers/pump_app.dart';
@@ -40,11 +42,22 @@ void main() {
     if (sl.isRegistered<DioClient>()) {
       sl.unregister<DioClient>();
     }
+    if (sl.isRegistered<ImageLoadingStrategy>()) {
+      sl.unregister<ImageLoadingStrategy>();
+    }
     sl.registerSingleton<DioClient>(mockDioClient);
+    sl.registerSingleton<ImageLoadingStrategy>(
+      DioImageLoadingStrategy(mockDioClient),
+    );
   });
 
   tearDown(() {
-    sl.unregister<DioClient>();
+    if (sl.isRegistered<DioClient>()) {
+      sl.unregister<DioClient>();
+    }
+    if (sl.isRegistered<ImageLoadingStrategy>()) {
+      sl.unregister<ImageLoadingStrategy>();
+    }
   });
 
   final testBook = Book(

--- a/test/features/books/presentation/components/organisms/book_list_test.dart
+++ b/test/features/books/presentation/components/organisms/book_list_test.dart
@@ -4,6 +4,8 @@ import 'package:gatuno/features/books/domain/entities/book.dart';
 import 'package:gatuno/features/books/domain/entities/book_type.dart';
 import 'package:gatuno/features/books/presentation/components/organisms/book_list.dart';
 import 'package:gatuno/core/di/injection.dart';
+import 'package:gatuno/core/image/dio_image_loading_strategy.dart';
+import 'package:gatuno/core/image/image_loading_strategy.dart';
 import 'package:gatuno/core/network/dio_client.dart';
 import 'package:mocktail/mocktail.dart';
 import '../../../../../helpers/pump_app.dart';
@@ -18,11 +20,22 @@ void main() {
     if (sl.isRegistered<DioClient>()) {
       sl.unregister<DioClient>();
     }
+    if (sl.isRegistered<ImageLoadingStrategy>()) {
+      sl.unregister<ImageLoadingStrategy>();
+    }
     sl.registerSingleton<DioClient>(mockDioClient);
+    sl.registerSingleton<ImageLoadingStrategy>(
+      DioImageLoadingStrategy(mockDioClient),
+    );
   });
 
   tearDown(() {
-    sl.unregister<DioClient>();
+    if (sl.isRegistered<DioClient>()) {
+      sl.unregister<DioClient>();
+    }
+    if (sl.isRegistered<ImageLoadingStrategy>()) {
+      sl.unregister<ImageLoadingStrategy>();
+    }
   });
 
   final testBooks = List.generate(

--- a/test/features/books/presentation/views/book_details_screen_test.dart
+++ b/test/features/books/presentation/views/book_details_screen_test.dart
@@ -1,8 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:gatuno/core/di/injection.dart';
-import 'package:gatuno/core/network/dio_client.dart';
 import 'package:gatuno/features/books/domain/entities/author.dart';
 import 'package:gatuno/features/books/domain/entities/book.dart';
 import 'package:gatuno/features/books/domain/entities/chapter.dart' as entity;
@@ -11,30 +9,21 @@ import 'package:gatuno/features/books/presentation/views/book_details_screen.dar
 import 'package:mocktail/mocktail.dart';
 import 'package:provider/provider.dart';
 import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/test_injection.dart';
 
 class MockBookDetailsViewModel extends Mock implements BookDetailsViewModel {}
-
-class MockDioClient extends Mock implements DioClient {}
-
-class MockDio extends Mock implements Dio {}
 
 void main() {
   late MockBookDetailsViewModel mockViewModel;
   late MockDioClient mockDioClient;
   late MockDio mockDio;
 
-  setUpAll(() {
+  setUp(() async {
     mockDioClient = MockDioClient();
-    mockDio = MockDio();
-    when(() => mockDioClient.dio).thenReturn(mockDio);
+    mockDio = mockDioClient.dio as MockDio;
 
-    sl.registerSingleton<DioClient>(mockDioClient);
+    await initTestDI(dioClient: mockDioClient);
 
-    // Register fallback for any()
-    registerFallbackValue(RequestOptions(path: ''));
-  });
-
-  setUp(() {
     mockViewModel = MockBookDetailsViewModel();
 
     when(() => mockViewModel.isLoading).thenReturn(false);
@@ -51,6 +40,7 @@ void main() {
     when(() => mockViewModel.removeListener(any())).thenReturn(null);
 
     // Mock dio get for images
+    registerFallbackValue(RequestOptions(path: ''));
     when(
       () => mockDio.get<List<int>>(any(), options: any(named: 'options')),
     ).thenAnswer(

--- a/test/features/reading/domain/entities/reading_chapter_test.dart
+++ b/test/features/reading/domain/entities/reading_chapter_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gatuno/features/reading/domain/entities/reading_chapter.dart';
 import 'package:gatuno/features/reading/domain/entities/reading_enums.dart';
+import 'package:gatuno/shared/domain/entities/image_metadata.dart';
 
 void main() {
   group('ReadingChapter', () {
@@ -31,8 +32,7 @@ void main() {
         id: 'p1',
         url: 'url',
         index: 0,
-        width: 100,
-        height: 200,
+        metadata: const ImageMetadata(width: 100, height: 200),
       );
 
       expect(page.id, 'p1');

--- a/test/features/reading/presentation/components/molecules/image_reader_item_test.dart
+++ b/test/features/reading/presentation/components/molecules/image_reader_item_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gatuno/features/reading/domain/entities/reading_chapter.dart';
 import 'package:gatuno/features/reading/presentation/components/molecules/image_reader_item.dart';
+import 'package:gatuno/shared/domain/entities/image_metadata.dart';
 import 'package:gatuno/shared/utils/image_aspect_ratio_cache.dart';
 import 'package:mocktail/mocktail.dart';
 import '../../../../../helpers/test_injection.dart';
@@ -30,8 +31,7 @@ void main() {
     id: '1',
     url: 'http://example.com/image.png',
     index: 0,
-    width: 100,
-    height: 200,
+    metadata: const ImageMetadata(width: 100, height: 200),
   );
 
   group('ImageReaderItem', () {

--- a/test/features/reading/presentation/components/molecules/image_reader_item_test.dart
+++ b/test/features/reading/presentation/components/molecules/image_reader_item_test.dart
@@ -151,7 +151,9 @@ void main() {
         0.5,
       );
 
-      await tester.pumpAndSettle();
+      await tester.pump(); // Start fetch
+      await tester.pump(); // Finish fetch
+      await tester.pump(); // Finish image frame build
 
       // Updated aspect ratio from 1x1 image (1.0)
       expect(

--- a/test/features/reading/presentation/components/organisms/image_reader_test.dart
+++ b/test/features/reading/presentation/components/organisms/image_reader_test.dart
@@ -5,6 +5,7 @@ import 'package:gatuno/features/reading/presentation/components/organisms/image_
 import 'package:gatuno/features/reading/presentation/components/organisms/reading_bottom_overlay.dart';
 import 'package:gatuno/features/reading/presentation/components/organisms/reading_top_overlay.dart';
 import 'package:gatuno/features/reading/presentation/view_models/reading_view_model.dart';
+import 'package:gatuno/shared/domain/entities/image_metadata.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:provider/provider.dart';
 import '../../../../../helpers/pump_app.dart';
@@ -39,11 +40,14 @@ class _MockPage extends Fake implements ReadingPage {
   @override
   final int index;
   @override
-  final double? width = 100;
-  @override
-  final double? height = 200;
+  final ImageMetadata? metadata = const ImageMetadata(width: 100, height: 200);
 
   _MockPage({required this.id, required this.url, required this.index});
+
+  @override
+  double? get width => metadata?.width;
+  @override
+  double? get height => metadata?.height;
 }
 
 void main() {

--- a/test/helpers/test_injection.dart
+++ b/test/helpers/test_injection.dart
@@ -1,5 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:gatuno/core/di/injection.dart';
+import 'package:gatuno/core/image/dio_image_loading_strategy.dart';
+import 'package:gatuno/core/image/image_loading_strategy.dart';
 import 'package:gatuno/core/network/dio_client.dart';
 import 'package:gatuno/core/network/token_provider.dart';
 import 'package:gatuno/features/authentication/domain/use_cases/auth_service.dart';
@@ -82,6 +84,9 @@ Future<void> initTestDI({
 
   final dc = dioClient ?? MockDioClient();
   sl.registerLazySingleton<DioClient>(() => dc);
+  sl.registerLazySingleton<ImageLoadingStrategy>(
+    () => DioImageLoadingStrategy(dc),
+  );
 
   final storage = authStorage ?? MockAuthStorage();
   if (authStorage == null) {
@@ -102,7 +107,7 @@ Future<void> initTestDI({
   sl.registerLazySingleton<SettingsService>(() => sService);
 
   final tm = tokenManager ?? MockTokenManager();
-  if (tokenManager == null) {
+  if (tm is MockTokenManager) {
     when(() => tm.initialize()).thenAnswer((_) async {});
     when(() => tm.getToken()).thenAnswer((_) async => null);
     when(
@@ -124,7 +129,7 @@ Future<void> initTestDI({
   }
 
   final navVM = navigationViewModel ?? MockNavigationViewModel();
-  if (navigationViewModel == null) {
+  if (navVM is MockNavigationViewModel) {
     when(() => navVM.isAuthenticated).thenReturn(false);
     when(() => navVM.user).thenReturn(null);
   }

--- a/test/shared/components/atoms/app_image_test.dart
+++ b/test/shared/components/atoms/app_image_test.dart
@@ -211,6 +211,92 @@ void main() {
       expect(find.byType(Image), findsOneWidget);
     });
 
+    testWidgets('does not use AnimatedOpacity when blurHash is null', (
+      WidgetTester tester,
+    ) async {
+      final transparentPng = Uint8List.fromList([
+        0x89,
+        0x50,
+        0x4E,
+        0x47,
+        0x0D,
+        0x0A,
+        0x1A,
+        0x0A,
+        0x00,
+        0x00,
+        0x00,
+        0x0D,
+        0x49,
+        0x48,
+        0x44,
+        0x52,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x08,
+        0x06,
+        0x00,
+        0x00,
+        0x00,
+        0x1F,
+        0x15,
+        0xC4,
+        0x89,
+        0x00,
+        0x00,
+        0x00,
+        0x0A,
+        0x49,
+        0x44,
+        0x41,
+        0x54,
+        0x78,
+        0x9C,
+        0x63,
+        0x00,
+        0x01,
+        0x00,
+        0x00,
+        0x05,
+        0x00,
+        0x01,
+        0x0D,
+        0x0A,
+        0x2D,
+        0xB4,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x49,
+        0x45,
+        0x4E,
+        0x44,
+        0xAE,
+        0x42,
+        0x60,
+        0x82,
+      ]);
+
+      when(
+        () => mockStrategy.loadImage(
+          any(),
+          onImageLoaded: any(named: 'onImageLoaded'),
+        ),
+      ).thenAnswer((_) async => transparentPng);
+
+      await tester.pumpWidget(createWidget('http://example.com/image.png'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AnimatedOpacity), findsNothing);
+    });
+
     testWidgets('calls onImageLoaded with correct dimensions', (
       WidgetTester tester,
     ) async {

--- a/test/shared/components/atoms/app_image_test.dart
+++ b/test/shared/components/atoms/app_image_test.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_blurhash/flutter_blurhash.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gatuno/shared/components/atoms/app_image.dart';
 import 'package:gatuno/shared/components/atoms/app_skeleton.dart';
@@ -44,6 +45,37 @@ void main() {
       await tester.pumpWidget(createWidget('http://example.com/image.png'));
 
       expect(find.byType(AppSkeleton), findsOneWidget);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('shows blurHash while loading when provided', (
+      WidgetTester tester,
+    ) async {
+      when(
+        () => mockDio.get<List<int>>(any(), options: any(named: 'options')),
+      ).thenAnswer((_) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return Response<List<int>>(
+          data: [1, 2, 3],
+          statusCode: 200,
+          requestOptions: RequestOptions(path: ''),
+        );
+      });
+
+      const blurHash = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppImage(
+              imageUrl: 'http://example.com/image.png',
+              blurHash: blurHash,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(BlurHash), findsOneWidget);
       await tester.pumpAndSettle();
     });
 

--- a/test/shared/components/atoms/app_image_test.dart
+++ b/test/shared/components/atoms/app_image_test.dart
@@ -1,29 +1,28 @@
 import 'dart:typed_data';
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:gatuno/core/image/image_loading_strategy.dart';
 import 'package:gatuno/shared/components/atoms/app_image.dart';
 import 'package:gatuno/shared/components/atoms/app_skeleton.dart';
 import 'package:mocktail/mocktail.dart';
 import '../../../helpers/test_injection.dart';
 
+class MockImageLoadingStrategy extends Mock implements ImageLoadingStrategy {}
+
 void main() {
-  late MockDioClient mockDioClient;
-  late MockDio mockDio;
+  late MockImageLoadingStrategy mockStrategy;
 
   setUp(() async {
-    mockDioClient = MockDioClient();
-    mockDio = mockDioClient.dio as MockDio;
-
-    await initTestDI(dioClient: mockDioClient);
-
-    registerFallbackValue(RequestOptions(path: ''));
+    mockStrategy = MockImageLoadingStrategy();
+    await initTestDI();
   });
 
-  Widget createWidget(String url) {
+  Widget createWidget(String url, {ImageLoadingStrategy? strategy}) {
     return MaterialApp(
-      home: Scaffold(body: AppImage(imageUrl: url)),
+      home: Scaffold(
+        body: AppImage(imageUrl: url, strategy: strategy ?? mockStrategy),
+      ),
     );
   }
 
@@ -32,14 +31,13 @@ void main() {
       WidgetTester tester,
     ) async {
       when(
-        () => mockDio.get<List<int>>(any(), options: any(named: 'options')),
+        () => mockStrategy.loadImage(
+          any(),
+          onImageLoaded: any(named: 'onImageLoaded'),
+        ),
       ).thenAnswer((_) async {
         await Future<void>.delayed(const Duration(milliseconds: 100));
-        return Response<List<int>>(
-          data: [1, 2, 3],
-          statusCode: 200,
-          requestOptions: RequestOptions(path: ''),
-        );
+        return Uint8List.fromList([1, 2, 3]);
       });
 
       await tester.pumpWidget(createWidget('http://example.com/image.png'));
@@ -52,14 +50,13 @@ void main() {
       WidgetTester tester,
     ) async {
       when(
-        () => mockDio.get<List<int>>(any(), options: any(named: 'options')),
+        () => mockStrategy.loadImage(
+          any(),
+          onImageLoaded: any(named: 'onImageLoaded'),
+        ),
       ).thenAnswer((_) async {
         await Future<void>.delayed(const Duration(milliseconds: 100));
-        return Response<List<int>>(
-          data: [1, 2, 3],
-          statusCode: 200,
-          requestOptions: RequestOptions(path: ''),
-        );
+        return Uint8List.fromList([1, 2, 3]);
       });
 
       const blurHash = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
@@ -69,6 +66,7 @@ void main() {
           home: Scaffold(
             body: AppImage(
               imageUrl: 'http://example.com/image.png',
+              strategy: mockStrategy,
               blurHash: blurHash,
             ),
           ),
@@ -83,8 +81,11 @@ void main() {
       WidgetTester tester,
     ) async {
       when(
-        () => mockDio.get<List<int>>(any(), options: any(named: 'options')),
-      ).thenThrow(DioException(requestOptions: RequestOptions(path: '')));
+        () => mockStrategy.loadImage(
+          any(),
+          onImageLoaded: any(named: 'onImageLoaded'),
+        ),
+      ).thenAnswer((_) async => null);
 
       await tester.pumpWidget(createWidget('http://example.com/image.png'));
       await tester.pumpAndSettle();
@@ -96,8 +97,11 @@ void main() {
       WidgetTester tester,
     ) async {
       when(
-        () => mockDio.get<List<int>>(any(), options: any(named: 'options')),
-      ).thenThrow(DioException(requestOptions: RequestOptions(path: '')));
+        () => mockStrategy.loadImage(
+          any(),
+          onImageLoaded: any(named: 'onImageLoaded'),
+        ),
+      ).thenAnswer((_) async => null);
 
       const placeholderKey = Key('placeholder');
       const errorKey = Key('error');
@@ -107,6 +111,7 @@ void main() {
           home: Scaffold(
             body: AppImage(
               imageUrl: 'http://example.com/image.png',
+              strategy: mockStrategy,
               placeholder: const SizedBox(key: placeholderKey),
               errorWidget: const SizedBox(key: errorKey),
             ),
@@ -117,25 +122,6 @@ void main() {
 
       expect(find.byKey(errorKey), findsOneWidget);
       expect(find.byKey(placeholderKey), findsNothing);
-    });
-
-    testWidgets('shows error widget when data is null', (
-      WidgetTester tester,
-    ) async {
-      when(
-        () => mockDio.get<List<int>>(any(), options: any(named: 'options')),
-      ).thenAnswer(
-        (_) async => Response<List<int>>(
-          data: null,
-          statusCode: 200,
-          requestOptions: RequestOptions(path: ''),
-        ),
-      );
-
-      await tester.pumpWidget(createWidget('http://example.com/image.png'));
-      await tester.pumpAndSettle();
-
-      expect(find.byIcon(Icons.broken_image), findsOneWidget);
     });
 
     testWidgets('renders Image.memory when fetch is successful', (
@@ -213,14 +199,11 @@ void main() {
       ]);
 
       when(
-        () => mockDio.get<List<int>>(any(), options: any(named: 'options')),
-      ).thenAnswer(
-        (_) async => Response<List<int>>(
-          data: transparentPng,
-          statusCode: 200,
-          requestOptions: RequestOptions(path: ''),
+        () => mockStrategy.loadImage(
+          any(),
+          onImageLoaded: any(named: 'onImageLoaded'),
         ),
-      );
+      ).thenAnswer((_) async => transparentPng);
 
       await tester.pumpWidget(createWidget('http://example.com/image.png'));
       await tester.pumpAndSettle();
@@ -231,86 +214,17 @@ void main() {
     testWidgets('calls onImageLoaded with correct dimensions', (
       WidgetTester tester,
     ) async {
-      // 1x1 transparent PNG
-      final transparentPng = Uint8List.fromList([
-        0x89,
-        0x50,
-        0x4E,
-        0x47,
-        0x0D,
-        0x0A,
-        0x1A,
-        0x0A,
-        0x00,
-        0x00,
-        0x00,
-        0x0D,
-        0x49,
-        0x48,
-        0x44,
-        0x52,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x08,
-        0x06,
-        0x00,
-        0x00,
-        0x00,
-        0x1F,
-        0x15,
-        0xC4,
-        0x89,
-        0x00,
-        0x00,
-        0x00,
-        0x0A,
-        0x49,
-        0x44,
-        0x41,
-        0x54,
-        0x78,
-        0x9C,
-        0x63,
-        0x00,
-        0x01,
-        0x00,
-        0x00,
-        0x05,
-        0x00,
-        0x01,
-        0x0D,
-        0x0A,
-        0x2D,
-        0xB4,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x49,
-        0x45,
-        0x4E,
-        0x44,
-        0xAE,
-        0x42,
-        0x60,
-        0x82,
-      ]);
-
       when(
-        () => mockDio.get<List<int>>(any(), options: any(named: 'options')),
-      ).thenAnswer(
-        (_) async => Response<List<int>>(
-          data: transparentPng,
-          statusCode: 200,
-          requestOptions: RequestOptions(path: ''),
+        () => mockStrategy.loadImage(
+          any(),
+          onImageLoaded: any(named: 'onImageLoaded'),
         ),
-      );
+      ).thenAnswer((invocation) async {
+        final onImageLoaded =
+            invocation.namedArguments[#onImageLoaded] as void Function(Size)?;
+        onImageLoaded?.call(const Size(1.0, 1.0));
+        return Uint8List(0);
+      });
 
       Size? loadedSize;
       await tester.pumpWidget(
@@ -318,6 +232,7 @@ void main() {
           home: Scaffold(
             body: AppImage(
               imageUrl: 'http://example.com/image.png',
+              strategy: mockStrategy,
               onImageLoaded: (size) => loadedSize = size,
             ),
           ),
@@ -336,32 +251,73 @@ void main() {
         WidgetTester tester,
       ) async {
         when(
-          () => mockDio.get<List<int>>(any(), options: any(named: 'options')),
-        ).thenAnswer(
-          (_) async => Response<List<int>>(
-            data: [1, 2],
-            statusCode: 200,
-            requestOptions: RequestOptions(path: ''),
+          () => mockStrategy.loadImage(
+            any(),
+            onImageLoaded: any(named: 'onImageLoaded'),
           ),
-        );
+        ).thenAnswer((_) async => Uint8List(0));
 
         await tester.pumpWidget(createWidget('http://example.com/image1.png'));
         await tester.pumpAndSettle();
 
         verify(
-          () => mockDio.get<List<int>>(
+          () => mockStrategy.loadImage(
             'http://example.com/image1.png',
-            options: any(named: 'options'),
+            onImageLoaded: any(named: 'onImageLoaded'),
           ),
         ).called(1);
 
         await tester.pumpWidget(createWidget('http://example.com/image2.png'));
-        await tester.pump(); // Start fetching
+        await tester.pump();
 
         verify(
-          () => mockDio.get<List<int>>(
+          () => mockStrategy.loadImage(
             'http://example.com/image2.png',
-            options: any(named: 'options'),
+            onImageLoaded: any(named: 'onImageLoaded'),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('refetches when strategy changes', (
+        WidgetTester tester,
+      ) async {
+        final strategy1 = MockImageLoadingStrategy();
+        final strategy2 = MockImageLoadingStrategy();
+
+        when(
+          () => strategy1.loadImage(
+            any(),
+            onImageLoaded: any(named: 'onImageLoaded'),
+          ),
+        ).thenAnswer((_) async => Uint8List(0));
+        when(
+          () => strategy2.loadImage(
+            any(),
+            onImageLoaded: any(named: 'onImageLoaded'),
+          ),
+        ).thenAnswer((_) async => Uint8List(0));
+
+        await tester.pumpWidget(
+          createWidget('http://example.com/image.png', strategy: strategy1),
+        );
+        await tester.pumpAndSettle();
+
+        verify(
+          () => strategy1.loadImage(
+            'http://example.com/image.png',
+            onImageLoaded: any(named: 'onImageLoaded'),
+          ),
+        ).called(1);
+
+        await tester.pumpWidget(
+          createWidget('http://example.com/image.png', strategy: strategy2),
+        );
+        await tester.pump();
+
+        verify(
+          () => strategy2.loadImage(
+            'http://example.com/image.png',
+            onImageLoaded: any(named: 'onImageLoaded'),
           ),
         ).called(1);
       });


### PR DESCRIPTION
Close #16 

- Added ImageMetadata entity and model for shared use across features.
- Integrated flutter_blurhash to provide visual placeholders during image loading.
- Refactored AppImage to support staggered fade-in animations for a smoother UX.
- Updated Book and ReadingPage entities/models to include image metadata.
- Propagated blurHash through BookCover and ImageReader components.
- Enhanced unit and widget tests to cover metadata and blurhash functionality.